### PR TITLE
Enhance Table Canvas with Primary Key Indicator and Unique Attribute Enforcement upon PrimaryKey toggle

### DIFF
--- a/src/pages/editor-page/canvas/table-node-field.tsx
+++ b/src/pages/editor-page/canvas/table-node-field.tsx
@@ -88,7 +88,12 @@ export const TableNodeField: React.FC<TableNodeFieldProps> = ({
             <div className="block w-2/3 text-left overflow-hidden whitespace-nowrap text-ellipsis">
                 {field.name}
             </div>
-            <div className="flex justify-end w-1/3">
+            <div className="flex justify-end w-2/3">
+                {field.primaryKey? (
+                    <div className="text-muted-foreground block group-hover:hidden text-xs text-center overflow-hidden whitespace-nowrap text-ellipsis w-full">
+                        Primary
+                    </div>
+                ): ""}
                 <div className="text-muted-foreground block group-hover:hidden text-xs text-right overflow-hidden whitespace-nowrap text-ellipsis w-full">
                     {field.type}
                 </div>

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-content/table-field/table-field.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-content/table-field/table-field.tsx
@@ -95,6 +95,7 @@ export const TableField: React.FC<TableFieldProps> = ({
                             pressed={field.primaryKey}
                             onPressedChange={(value) =>
                                 updateField({
+                                    unique: value,
                                     primaryKey: value,
                                 })
                             }
@@ -128,6 +129,7 @@ export const TableField: React.FC<TableFieldProps> = ({
                                 </Label>
                                 <Checkbox
                                     checked={field.unique}
+                                    disabled={field.primaryKey}
                                     onCheckedChange={(value) =>
                                         updateField({
                                             unique: !!value,


### PR DESCRIPTION
## ISSUES_ADDRESSED:
- Issue #23: Introduced a primary key indicator on the table canvas to mark fields designated as primary keys.
- Issue #26: Added logic to enforce the unique attribute when toggling the primary key status on fields

This PR improves the user experience by visually indicating primary keys and maintaining schema integrity through proper attribute enforcement.


## SCREENSHOTS
![image](https://github.com/user-attachments/assets/c9666b46-af20-4a45-a6b5-38b60692629f)
![image](https://github.com/user-attachments/assets/c8f4ca39-add0-422d-b58b-7a4741d74cb4)
![image](https://github.com/user-attachments/assets/5fb3d0c7-6e83-45e9-aa25-8b55702d657b)
