### PR TITLE
Fixed validateDOMNesting warning

### DIFF
--- a/src/pages/editor-page/side-panel/list-item-header-button/relationship-list-item-header-button.tsx
+++ b/src/pages/editor-page/side-panel/list-item-header-button/relationship-list-item-header-button.tsx
@@ -9,7 +9,8 @@ export const ListItemHeaderButton: React.FC<ButtonProps> = React.forwardRef<
         <Button
             ref={ref}
             variant="ghost"
-            className="hover:bg-primary-foreground p-2 w-8 h-8 text-slate-500 hover:text-slate-700"
+            className="hover:bg-primary-foreground hover:cursor-pointer p-2 w-8 h-8 text-slate-500 hover:text-slate-700"
+            asChild
             {...props}
         />
     );

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-content/table-field/table-field.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-content/table-field/table-field.tsx
@@ -71,42 +71,46 @@ export const TableField: React.FC<TableFieldProps> = ({
             </div>
             <div className="flex w-4/12 gap-1 justify-end overflow-hidden">
                 <Tooltip>
-                    <TooltipTrigger>
-                        <Toggle
-                            variant="default"
-                            className="hover:bg-primary-foreground p-2 w-[32px] text-slate-500 hover:text-slate-700 text-xs h-8"
-                            pressed={field.nullable}
-                            onPressedChange={(value) =>
-                                updateField({
-                                    nullable: value,
-                                })
-                            }
-                        >
-                            N
-                        </Toggle>
+                    <TooltipTrigger asChild>
+                        <span>
+                            <Toggle
+                                variant="default"
+                                className="hover:bg-primary-foreground p-2 w-[32px] text-slate-500 hover:text-slate-700 text-xs h-8"
+                                pressed={field.nullable}
+                                onPressedChange={(value) =>
+                                    updateField({
+                                        nullable: value,
+                                    })
+                                }
+                            >
+                                N
+                            </Toggle>
+                        </span>
                     </TooltipTrigger>
                     <TooltipContent>Nullable?</TooltipContent>
                 </Tooltip>
                 <Tooltip>
-                    <TooltipTrigger>
-                        <Toggle
-                            variant="default"
-                            className="hover:bg-primary-foreground p-2 w-[32px] text-slate-500 hover:text-slate-700 h-8"
-                            pressed={field.primaryKey}
-                            onPressedChange={(value) =>
-                                updateField({
-                                    unique: value,
-                                    primaryKey: value,
-                                })
-                            }
-                        >
-                            <KeyRound className="h-3.5" />
-                        </Toggle>
+                    <TooltipTrigger asChild>
+                        <span>
+                            <Toggle
+                                variant="default"
+                                className="hover:bg-primary-foreground p-2 w-[32px] text-slate-500 hover:text-slate-700 h-8"
+                                pressed={field.primaryKey}
+                                onPressedChange={(value) =>
+                                    updateField({
+                                        unique: value,
+                                        primaryKey: value,
+                                    })
+                                }
+                            >
+                                <KeyRound className="h-3.5" />
+                            </Toggle>
+                        </span>
                     </TooltipTrigger>
                     <TooltipContent>Primary Key</TooltipContent>
                 </Tooltip>
                 <Popover>
-                    <PopoverTrigger>
+                    <PopoverTrigger asChild>
                         <Button
                             variant="ghost"
                             className="hover:bg-primary-foreground p-2 w-[32px] text-slate-500 hover:text-slate-700 h-8"

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-content/table-index/table-index.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-content/table-index/table-index.tsx
@@ -49,7 +49,7 @@ export const TableIndex: React.FC<TableIndexProps> = ({
             />
             <div className="flex">
                 <Popover>
-                    <PopoverTrigger>
+                    <PopoverTrigger asChild>
                         <Button
                             variant="ghost"
                             className="hover:bg-primary-foreground p-2 w-[32px] text-slate-500 hover:text-slate-700 h-8"

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-content/table-list-item-content.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-content/table-list-item-content.tsx
@@ -68,6 +68,7 @@ export const TableListItemContent: React.FC<TableListItemContentProps> = ({
                     <AccordionTrigger
                         iconPosition="right"
                         className="p-0 px-2 text-xs text-slate-600 flex flex-1 hover:bg-secondary py-1 group"
+                        asChild
                     >
                         <div className="flex items-center justify-between flex-1">
                             <div className="flex flex-row items-center gap-1">
@@ -110,6 +111,7 @@ export const TableListItemContent: React.FC<TableListItemContentProps> = ({
                     <AccordionTrigger
                         iconPosition="right"
                         className="p-0 px-2 text-xs text-slate-600 flex flex-1 hover:bg-secondary py-1 group"
+                        asChild
                     >
                         <div className="flex items-center justify-between flex-1">
                             <div className="flex flex-row items-center gap-1">


### PR DESCRIPTION
Possibly closes #21 
Used asChild prop wherever possible to evade use of button tag and remove any nesting
In case of Tooltip + Toggle combination using asChild is causing conflict between the data-states so the toggle is wrapped in span to seperate them