### PR TITLE
fix: rounded table node

### DIFF
--- a/src/pages/editor-page/canvas/table-node-field.tsx
+++ b/src/pages/editor-page/canvas/table-node-field.tsx
@@ -42,7 +42,7 @@ export const TableNodeField: React.FC<TableNodeFieldProps> = ({
     }, [tableNodeId, updateNodeInternals, numberOfEdgesToField]);
 
     return (
-        <div className="flex relative items-center h-8 text-sm px-3 border-t justify-between hover:bg-slate-100 group last:rounded-b-lg">
+        <div className="flex relative items-center h-8 text-sm px-3 border-t justify-between hover:bg-slate-100 group last:rounded-b-[6px]">
             {!connection.inProgress && (
                 <>
                     <Handle

--- a/src/pages/editor-page/canvas/table-node.tsx
+++ b/src/pages/editor-page/canvas/table-node.tsx
@@ -72,7 +72,7 @@ export const TableNode: React.FC<NodeProps<TableNodeType>> = ({
                 handleClassName="!hidden"
             />
             <div
-                className="h-2 rounded-t-lg"
+                className="h-2 rounded-t-[6px]"
                 style={{ backgroundColor: table.color }}
             ></div>
             <div className="flex items-center h-9 bg-slate-200 px-2 justify-between group">


### PR DESCRIPTION
Hi, Severin from @tremorlabs here :)

Just found and fixed a small visual inconsistency. The `table-node` and `table-node-field` had a small gap in the corners because the rounded utility `lg` added too much radius. I replaced it with a custom value, closing the gap.

![CleanShot 2024-09-01 at 01 31 13@2x](https://github.com/user-attachments/assets/37947081-814f-4799-ad1c-ab1cfeb8f04c)
![CleanShot 2024-09-01 at 01 31 01@2x](https://github.com/user-attachments/assets/6aa4c7a0-0720-4c15-9135-4b0bbd56e5ee)
