### PR TITLE
fix: zoom in/out on scroll instead of panning

### DIFF
--- a/src/context/scroll-context/scroll-context.tsx
+++ b/src/context/scroll-context/scroll-context.tsx
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+import { emptyFn } from '@/lib/utils';
+
+export type ScrollActionType = 'pan' | 'zoom';
+
+export interface ScrollContext {
+    scrollAction: ScrollActionType;
+    setScrollAction: (action: ScrollActionType) => void;
+    effectiveScrollAction: ScrollActionType;
+}
+
+export const ScrollContext = createContext<ScrollContext>({
+    scrollAction: 'pan',
+    setScrollAction: emptyFn,
+    effectiveScrollAction: 'pan',
+});

--- a/src/context/scroll-context/scroll-context.tsx
+++ b/src/context/scroll-context/scroll-context.tsx
@@ -6,11 +6,9 @@ export type ScrollActionType = 'pan' | 'zoom';
 export interface ScrollContext {
     scrollAction: ScrollActionType;
     setScrollAction: (action: ScrollActionType) => void;
-    effectiveScrollAction: ScrollActionType;
 }
 
 export const ScrollContext = createContext<ScrollContext>({
     scrollAction: 'pan',
     setScrollAction: emptyFn,
-    effectiveScrollAction: 'pan',
 });

--- a/src/context/scroll-context/scroll-provider.tsx
+++ b/src/context/scroll-context/scroll-provider.tsx
@@ -11,19 +11,12 @@ export const ScrollProvider: React.FC<React.PropsWithChildren> = ({
         return savedAction || 'pan';
     });
 
-    const [effectiveScrollAction, setEffectiveScrollAction] =
-        useState<ScrollActionType>('pan');
-
     useEffect(() => {
-        console.log('coucou');
         localStorage.setItem('scrollAction', scrollAction);
-        setEffectiveScrollAction(scrollAction);
     }, [scrollAction]);
 
     return (
-        <ScrollContext.Provider
-            value={{ scrollAction, setScrollAction, effectiveScrollAction }}
-        >
+        <ScrollContext.Provider value={{ scrollAction, setScrollAction }}>
             {children}
         </ScrollContext.Provider>
     );

--- a/src/context/scroll-context/scroll-provider.tsx
+++ b/src/context/scroll-context/scroll-provider.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+import { ScrollContext, ScrollActionType } from './scroll-context';
+
+export const ScrollProvider: React.FC<React.PropsWithChildren> = ({
+    children,
+}) => {
+    const [scrollAction, setScrollAction] = useState<ScrollActionType>(() => {
+        const savedAction = localStorage.getItem(
+            'scrollAction'
+        ) as ScrollActionType | null;
+        return savedAction || 'pan';
+    });
+
+    const [effectiveScrollAction, setEffectiveScrollAction] =
+        useState<ScrollActionType>('pan');
+
+    useEffect(() => {
+        console.log('coucou');
+        localStorage.setItem('scrollAction', scrollAction);
+        setEffectiveScrollAction(scrollAction);
+    }, [scrollAction]);
+
+    return (
+        <ScrollContext.Provider
+            value={{ scrollAction, setScrollAction, effectiveScrollAction }}
+        >
+            {children}
+        </ScrollContext.Provider>
+    );
+};

--- a/src/hooks/use-scroll-action.ts
+++ b/src/hooks/use-scroll-action.ts
@@ -1,0 +1,4 @@
+import { ScrollContext } from '@/context/scroll-context/scroll-context';
+import { useContext } from 'react';
+
+export const useScrollAction = () => useContext(ScrollContext);

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -56,6 +56,11 @@ export const en = {
             dark: 'Dark',
         },
 
+        zoom: {
+            on: 'On',
+            off: 'Off',
+        },
+
         last_saved: 'Last saved',
         saved: 'Saved',
         diagrams: 'Diagrams',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -23,7 +23,7 @@ export const en = {
                 view: 'View',
                 show_sidebar: 'Show Sidebar',
                 hide_sidebar: 'Hide Sidebar',
-                zoom_on_scroll: 'Zoom on scroll',
+                zoom_on_scroll: 'Zoom on Scroll',
                 theme: 'Theme',
                 change_language: 'Language',
             },

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -23,6 +23,7 @@ export const en = {
                 view: 'View',
                 show_sidebar: 'Show Sidebar',
                 hide_sidebar: 'Hide Sidebar',
+                zoom_on_scroll: 'Zoom on scroll',
                 theme: 'Theme',
                 change_language: 'Language',
             },

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -56,6 +56,11 @@ export const es: LanguageTranslation = {
             dark: 'Oscuro',
         },
 
+        zoom: {
+            on: 'Encendido',
+            off: 'Apagado',
+        },
+
         last_saved: 'Último guardado',
         saved: 'Guardado',
         diagrams: 'Diagramas',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -23,6 +23,7 @@ export const es: LanguageTranslation = {
                 view: 'Ver',
                 show_sidebar: 'Mostrar Barra Lateral',
                 hide_sidebar: 'Ocultar Barra Lateral',
+                zoom_on_scroll: 'Zoom al desplazarse',
                 theme: 'Tema',
                 change_language: 'Idioma',
             },

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -23,7 +23,7 @@ export const es: LanguageTranslation = {
                 view: 'Ver',
                 show_sidebar: 'Mostrar Barra Lateral',
                 hide_sidebar: 'Ocultar Barra Lateral',
-                zoom_on_scroll: 'Zoom al desplazarse',
+                zoom_on_scroll: 'Zoom al Desplazarse',
                 theme: 'Tema',
                 change_language: 'Idioma',
             },

--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -285,7 +285,6 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables }) => {
                     animated: false,
                     type: 'table-edge',
                 }}
-                panOnScroll
             >
                 {isLoadingDOM ? (
                     <Controls

--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -65,7 +65,7 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables }) => {
     } = useChartDB();
     const { showSidePanel } = useLayout();
     const { effectiveTheme } = useTheme();
-    const { effectiveScrollAction } = useScrollAction();
+    const { scrollAction } = useScrollAction();
     const { isMd: isDesktop } = useBreakpoint('md');
     const nodeTypes = useMemo(() => ({ table: TableNode }), []);
     const edgeTypes = useMemo(() => ({ 'table-edge': TableEdge }), []);
@@ -287,7 +287,7 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables }) => {
                     animated: false,
                     type: 'table-edge',
                 }}
-                panOnScroll={effectiveScrollAction === 'pan'}
+                panOnScroll={scrollAction === 'pan'}
             >
                 {isLoadingDOM ? (
                     <Controls

--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -31,6 +31,7 @@ import { Badge } from '@/components/badge/badge';
 import { useTheme } from '@/hooks/use-theme';
 import { useTranslation } from 'react-i18next';
 import { DBTable } from '@/lib/domain/db-table';
+import { useScrollAction } from '@/hooks/use-scroll-action';
 
 type AddEdgeParams = Parameters<typeof addEdge<TableEdgeType>>[0];
 
@@ -64,6 +65,7 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables }) => {
     } = useChartDB();
     const { showSidePanel } = useLayout();
     const { effectiveTheme } = useTheme();
+    const { effectiveScrollAction } = useScrollAction();
     const { isMd: isDesktop } = useBreakpoint('md');
     const nodeTypes = useMemo(() => ({ table: TableNode }), []);
     const edgeTypes = useMemo(() => ({ 'table-edge': TableEdge }), []);
@@ -285,6 +287,7 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables }) => {
                     animated: false,
                     type: 'table-edge',
                 }}
+                panOnScroll={effectiveScrollAction === 'pan'}
             >
                 {isLoadingDOM ? (
                     <Controls

--- a/src/pages/editor-page/top-navbar/top-navbar.tsx
+++ b/src/pages/editor-page/top-navbar/top-navbar.tsx
@@ -278,14 +278,6 @@ export const TopNavbar: React.FC<TopNavbarProps> = () => {
         }
     }, [isSidePanelShowed, showSidePanel, hideSidePanel]);
 
-    const setPanOrZoomScrollAction = useCallback(() => {
-        if (scrollAction === 'zoom') {
-            setScrollAction('pan');
-        } else {
-            setScrollAction('zoom');
-        }
-    }, [scrollAction, setScrollAction]);
-
     const emojiAI = '✨';
 
     const changeLanguage = useCallback(
@@ -526,12 +518,29 @@ export const TopNavbar: React.FC<TopNavbarProps> = () => {
                                         : t('menu.view.show_sidebar')}
                                 </MenubarItem>
                                 <MenubarSeparator />
-                                <MenubarCheckboxItem
-                                    checked={scrollAction === 'zoom'}
-                                    onClick={setPanOrZoomScrollAction}
-                                >
-                                    {t('menu.view.zoom_on_scroll')}
-                                </MenubarCheckboxItem>
+                                <MenubarSub>
+                                    <MenubarSubTrigger>
+                                        {t('menu.view.zoom_on_scroll')}
+                                    </MenubarSubTrigger>
+                                    <MenubarSubContent>
+                                        <MenubarCheckboxItem
+                                            checked={scrollAction === 'zoom'}
+                                            onClick={() =>
+                                                setScrollAction('zoom')
+                                            }
+                                        >
+                                            {t('zoom.on')}
+                                        </MenubarCheckboxItem>
+                                        <MenubarCheckboxItem
+                                            checked={scrollAction === 'pan'}
+                                            onClick={() =>
+                                                setScrollAction('pan')
+                                            }
+                                        >
+                                            {t('zoom.off')}
+                                        </MenubarCheckboxItem>
+                                    </MenubarSubContent>
+                                </MenubarSub>
                                 <MenubarSeparator />
                                 <MenubarSub>
                                     <MenubarSubTrigger>

--- a/src/pages/editor-page/top-navbar/top-navbar.tsx
+++ b/src/pages/editor-page/top-navbar/top-navbar.tsx
@@ -45,6 +45,7 @@ import { useLayout } from '@/hooks/use-layout';
 import { useTheme } from '@/hooks/use-theme';
 import { enMetadata } from '@/i18n/locales/en';
 import { esMetadata } from '@/i18n/locales/es';
+import { useScrollAction } from '@/hooks/use-scroll-action';
 
 export interface TopNavbarProps {}
 
@@ -65,6 +66,7 @@ export const TopNavbar: React.FC<TopNavbarProps> = () => {
     } = useDialog();
     const { setTheme, theme } = useTheme();
     const { hideSidePanel, isSidePanelShowed, showSidePanel } = useLayout();
+    const { scrollAction, setScrollAction } = useScrollAction();
     const { effectiveTheme } = useTheme();
     const { t, i18n } = useTranslation();
     const { redo, undo, hasRedo, hasUndo } = useHistory();
@@ -275,6 +277,14 @@ export const TopNavbar: React.FC<TopNavbarProps> = () => {
             showSidePanel();
         }
     }, [isSidePanelShowed, showSidePanel, hideSidePanel]);
+
+    const setPanOrZoomScrollAction = useCallback(() => {
+        if (scrollAction === 'zoom') {
+            setScrollAction('pan');
+        } else {
+            setScrollAction('zoom');
+        }
+    }, [scrollAction, setScrollAction]);
 
     const emojiAI = '✨';
 
@@ -515,6 +525,13 @@ export const TopNavbar: React.FC<TopNavbarProps> = () => {
                                         ? t('menu.view.hide_sidebar')
                                         : t('menu.view.show_sidebar')}
                                 </MenubarItem>
+                                <MenubarSeparator />
+                                <MenubarCheckboxItem
+                                    checked={scrollAction === 'zoom'}
+                                    onClick={setPanOrZoomScrollAction}
+                                >
+                                    {t('menu.view.zoom_on_scroll')}
+                                </MenubarCheckboxItem>
                                 <MenubarSeparator />
                                 <MenubarSub>
                                     <MenubarSubTrigger>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -5,6 +5,7 @@ import { EditorPage } from './pages/editor-page/editor-page';
 import { ChartDBProvider } from './context/chartdb-context/chartdb-provider';
 import { ReactFlowProvider } from '@xyflow/react';
 import { StorageProvider } from './context/storage-context/storage-provider';
+import { ScrollProvider } from './context/scroll-context/scroll-provider';
 import { ConfigProvider } from './context/config-context/config-provider';
 import { HistoryProvider } from './context/history-context/history-provider';
 import { RedoUndoStackProvider } from './context/history-context/redo-undo-stack-provider';
@@ -29,13 +30,15 @@ const routes: RouteObject[] = [
                                     <HistoryProvider>
                                         <ThemeProvider>
                                             <DialogProvider>
-                                                <ReactFlowProvider>
-                                                    <ExportImageProvider>
-                                                        <KeyboardShortcutsProvider>
-                                                            <EditorPage />
-                                                        </KeyboardShortcutsProvider>
-                                                    </ExportImageProvider>
-                                                </ReactFlowProvider>
+                                                <ScrollProvider>
+                                                    <ReactFlowProvider>
+                                                        <ExportImageProvider>
+                                                            <KeyboardShortcutsProvider>
+                                                                <EditorPage />
+                                                            </KeyboardShortcutsProvider>
+                                                        </ExportImageProvider>
+                                                    </ReactFlowProvider>
+                                                </ScrollProvider>
                                             </DialogProvider>
                                         </ThemeProvider>
                                     </HistoryProvider>


### PR DESCRIPTION
It was not possible to zoom in or out with a mouse scroll in the grid because the panning was activated. 
Removed it to enable zoom on mouse scroll