### PR TITLE
Deal with zoom when filtering schemas

### DIFF
--- a/src/pages/editor-page/side-panel/side-panel.tsx
+++ b/src/pages/editor-page/side-panel/side-panel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import {
     Select,
     SelectContent,
@@ -15,12 +15,15 @@ import { useTranslation } from 'react-i18next';
 import type { SelectBoxOption } from '@/components/select-box/select-box';
 import { SelectBox } from '@/components/select-box/select-box';
 import { useChartDB } from '@/hooks/use-chartdb';
+import { useReactFlow } from '@xyflow/react';
+import { debounce } from '@/lib/utils';
 
 export interface SidePanelProps {}
 
 export const SidePanel: React.FC<SidePanelProps> = () => {
     const { t } = useTranslation();
     const { schemas, filterSchemas, filteredSchemas } = useChartDB();
+    const { fitView } = useReactFlow();
     const {
         selectSidebarSection,
         selectedSidebarSection,
@@ -28,6 +31,18 @@ export const SidePanel: React.FC<SidePanelProps> = () => {
         openSelectSchema,
         closeSelectSchema,
     } = useLayout();
+
+    useEffect(() => {
+        if (filteredSchemas !== undefined) {
+            debounce(() => {
+                fitView({
+                    duration: 500,
+                    padding: 0.1,
+                    maxZoom: 0.8,
+                });
+            }, 500)();
+        }
+    }, [filteredSchemas, fitView]);
 
     const schemasOptions: SelectBoxOption[] = useMemo(
         () =>


### PR DESCRIPTION
2 things: 

1. zoom out to fit smoothly when filter schemas 
2. remove the clear functionality and put it to be the same as the tables/relationships functionality

![image](https://github.com/user-attachments/assets/887313fc-fcfb-42ba-a0d3-7fa05afa1ee0)
