### PR TITLE
Fix UI overflow on "examples" page

### DIFF
--- a/src/pages/examples-page/example-card.tsx
+++ b/src/pages/examples-page/example-card.tsx
@@ -86,15 +86,17 @@ export const ExampleCard: React.FC<ExampleCardProps> = ({ example }) => {
                     </Button>
                 </div>
             </div>
-            <img
-                src={
-                    effectiveTheme === 'dark'
-                        ? example.imageDark
-                        : example.image
-                }
-                alt={example.name}
-                className="w-fit border-b"
-            />
+            <div className="grow overflow-hidden">
+                <img
+                    src={
+                        effectiveTheme === 'dark'
+                            ? example.imageDark
+                            : example.image
+                    }
+                    alt={example.name}
+                    className="w-fit object-cover"
+                />
+            </div>
             <div className="flex p-2 text-base">{example.description}</div>
         </div>
     );


### PR DESCRIPTION
Currently, there is a UI overflow on the [https://app.chartdb.io/examples](https://app.chartdb.io/examples) page. 

![CleanShot 2024-09-25 at 21 20 56@2x](https://github.com/user-attachments/assets/d00dff29-7fac-4ba5-acc5-07df7e0252d5)
