### PR TITLE
styles(select-box): allow using tab & space to show choices

### DIFF
--- a/src/components/select-box/select-box.tsx
+++ b/src/components/select-box/select-box.tsx
@@ -156,18 +156,19 @@ export const SelectBox = React.forwardRef<HTMLInputElement, SelectBoxProps>(
             [options, value, multiple]
         );
 
+        const handleKeyDown = React.useCallback(
+            (e: React.KeyboardEvent) => {
+                if (!isOpen && e.code.toLowerCase() === 'space') {
+                    e.preventDefault();
+                    onOpenChange(true);
+                }
+            },
+            [isOpen, onOpenChange]
+        );
+
         return (
             <Popover open={isOpen} onOpenChange={onOpenChange} modal={true}>
-                <PopoverTrigger
-                    asChild
-                    tabIndex={0}
-                    onKeyDown={(e) => {
-                        if (!isOpen && e.key === ' ') {
-                            e.preventDefault();
-                            onOpenChange(!isOpen);
-                        }
-                    }}
-                >
+                <PopoverTrigger asChild tabIndex={0} onKeyDown={handleKeyDown}>
                     <div
                         className={cn(
                             `flex min-h-[36px] cursor-pointer items-center justify-between rounded-md border px-3 py-1 data-[state=open]:border-ring ${disabled ? 'bg-muted pointer-events-none' : ''}`,

--- a/src/components/select-box/select-box.tsx
+++ b/src/components/select-box/select-box.tsx
@@ -158,7 +158,16 @@ export const SelectBox = React.forwardRef<HTMLInputElement, SelectBoxProps>(
 
         return (
             <Popover open={isOpen} onOpenChange={onOpenChange} modal={true}>
-                <PopoverTrigger asChild>
+                <PopoverTrigger
+                    asChild
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                        if (!isOpen && e.key === ' ') {
+                            e.preventDefault();
+                            onOpenChange(!isOpen);
+                        }
+                    }}
+                >
                     <div
                         className={cn(
                             `flex min-h-[36px] cursor-pointer items-center justify-between rounded-md border px-3 py-1 data-[state=open]:border-ring ${disabled ? 'bg-muted pointer-events-none' : ''}`,


### PR DESCRIPTION
## Summary of changes

Make SelectBox focusable with `tab` and on key press `space` it open the dropdown

Context: Allow to enter column name and type without leaving our keyboard

## Preview

https://github.com/user-attachments/assets/a1d3c8e9-b9e1-405c-af3e-b042886215de

