### PR TITLE
Added snap to grid for nodes when shift Key is held

### DIFF
--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -723,7 +723,7 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables, readonly }) => {
                     }}
                     panOnScroll={scrollAction === 'pan'}
                     snapToGrid={isShiftKeyPressed}
-                    snapGrid={[10, 10]}
+                    snapGrid={[20, 20]}
                     onNodeDrag={handleNodeDrag}
                     onNodeDragStop={handleNodeDragStop}
                 >

--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -148,6 +148,8 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables, readonly }) => {
     const [edges, setEdges, onEdgesChange] =
         useEdgesState<EdgeType>(initialEdges);
 
+    const [isShiftKeyPressed, setIsShiftKeyPressed] = useState<boolean>(false);
+
     useEffect(() => {
         setIsInitialLoadingNodes(true);
     }, [initialTables]);
@@ -688,6 +690,14 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables, readonly }) => {
         setTimeout(() => setHighlightOverlappingTables(false), 600);
     }, []);
 
+    const handleNodeDrag = useCallback((event: React.MouseEvent) => {
+        setIsShiftKeyPressed(event.shiftKey);
+    }, []);
+
+    const handleNodeDragStop = useCallback(() => {
+        setIsShiftKeyPressed(false);
+    }, []);
+
     return (
         <CanvasContextMenu>
             <div className="relative flex h-full">
@@ -712,6 +722,10 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables, readonly }) => {
                         type: 'relationship-edge',
                     }}
                     panOnScroll={scrollAction === 'pan'}
+                    snapToGrid={isShiftKeyPressed}
+                    snapGrid={[10, 10]}
+                    onNodeDrag={handleNodeDrag}
+                    onNodeDragStop={handleNodeDragStop}
                 >
                     <Controls
                         position="top-left"


### PR DESCRIPTION
Props passed to the canvas
```
snapToGrid={isShiftKeyPressed}  // boolean that toggles snap to grid
snapGrid={[10, 10]}
onNodeDrag={handleNodeDrag} // event listener to track node is being dragged
onNodeDragStop={handleNodeDragStop}
```

isShiftKeyPressed type boolean true when pressed
```
    const handleNodeDrag = useCallback((event: React.MouseEvent) => {
        setIsShiftKeyPressed(event.shiftKey);
    }, []);

    const handleNodeDragStop = useCallback(() => {
        setIsShiftKeyPressed(false);
    }, []);
```


