### PR TITLE
feat(i18n, canvas, context, side-panel): Duplication of tables

### DIFF
--- a/src/context/chartdb-context/chartdb-context.tsx
+++ b/src/context/chartdb-context/chartdb-context.tsx
@@ -122,6 +122,8 @@ export interface ChartDBContext {
         updateFn: (tables: DBTable[]) => PartialExcept<DBTable, 'id'>[],
         options?: { updateHistory: boolean; forceOverride?: boolean }
     ) => Promise<void>;
+    duplicateTable: (tableId: string) => Promise<DBTable>;
+    duplicateTables: (tableIds: string[]) => Promise<DBTable[]>;
 
     // Field operations
     getField: (tableId: string, fieldId: string) => DBField | null;
@@ -262,6 +264,8 @@ export const chartDBContext = createContext<ChartDBContext>({
     removeTables: emptyFn,
     updateTable: emptyFn,
     updateTablesState: emptyFn,
+    duplicateTable: emptyFn,
+    duplicateTables: emptyFn,
 
     // Field operations
     updateField: emptyFn,

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -145,6 +145,7 @@ export const de: LanguageTranslation = {
                         change_schema: 'Schema ändern',
                         add_field: 'Feld hinzufügen',
                         add_index: 'Index hinzufügen',
+                        duplicate_table: 'Duplicate Table', // TODO: Translate
                         delete_table: 'Tabelle löschen',
                     },
                 },
@@ -371,6 +372,7 @@ export const de: LanguageTranslation = {
 
         table_node_context_menu: {
             edit_table: 'Tabelle bearbeiten',
+            duplicate_table: 'Duplicate table', // TODO: Translate
             delete_table: 'Tabelle löschen',
         },
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -144,6 +144,7 @@ export const en = {
                         change_schema: 'Change Schema',
                         add_field: 'Add Field',
                         add_index: 'Add Index',
+                        duplicate_table: 'Duplicate Table',
                         delete_table: 'Delete Table',
                     },
                 },
@@ -367,6 +368,7 @@ export const en = {
 
         table_node_context_menu: {
             edit_table: 'Edit Table',
+            duplicate_table: 'Duplicate table',
             delete_table: 'Delete Table',
         },
 

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -136,6 +136,7 @@ export const es: LanguageTranslation = {
                         change_schema: 'Cambiar Esquema',
                         add_field: 'Agregar Campo',
                         add_index: 'Agregar Índice',
+                        duplicate_table: 'Duplicate Table', // TODO: Translate
                         delete_table: 'Eliminar Tabla',
                     },
                 },
@@ -371,6 +372,7 @@ export const es: LanguageTranslation = {
 
         table_node_context_menu: {
             edit_table: 'Editar Tabla',
+            duplicate_table: 'Duplicate table', // TODO: Translate
             delete_table: 'Eliminar Tabla',
         },
 

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -135,6 +135,7 @@ export const fr: LanguageTranslation = {
                         title: 'Actions de la Table',
                         add_field: 'Ajouter un Champ',
                         add_index: 'Ajouter un Index',
+                        duplicate_table: 'Duplicate Table', // TODO: Translate
                         delete_table: 'Supprimer la Table',
                         change_schema: 'Changer le Schéma',
                     },
@@ -373,6 +374,7 @@ export const fr: LanguageTranslation = {
 
         table_node_context_menu: {
             edit_table: 'Éditer la Table',
+            duplicate_table: 'Duplicate table', // TODO: Translate
             delete_table: 'Supprimer la Table',
         },
 

--- a/src/i18n/locales/hi.ts
+++ b/src/i18n/locales/hi.ts
@@ -146,6 +146,7 @@ export const hi: LanguageTranslation = {
                         change_schema: 'स्कीमा बदलें',
                         add_field: 'फ़ील्ड जोड़ें',
                         add_index: 'सूचकांक जोड़ें',
+                        duplicate_table: 'Duplicate Table', // TODO: Translate
                         delete_table: 'तालिका हटाएँ',
                     },
                 },
@@ -373,6 +374,7 @@ export const hi: LanguageTranslation = {
 
         table_node_context_menu: {
             edit_table: 'तालिका संपादित करें',
+            duplicate_table: 'Duplicate table', // TODO: Translate
             delete_table: 'तालिका हटाएँ',
         },
 

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -147,6 +147,7 @@ export const ja: LanguageTranslation = {
                         change_schema: 'スキーマを変更',
                         add_field: 'フィールドを追加',
                         add_index: 'インデックスを追加',
+                        duplicate_table: 'Duplicate Table', // TODO: Translate
                         delete_table: 'テーブルを削除',
                     },
                 },
@@ -375,6 +376,7 @@ export const ja: LanguageTranslation = {
 
         table_node_context_menu: {
             edit_table: 'テーブルを編集',
+            duplicate_table: 'Duplicate table', // TODO: Translate
             delete_table: 'テーブルを削除',
         },
 

--- a/src/i18n/locales/ko_KR.ts
+++ b/src/i18n/locales/ko_KR.ts
@@ -145,6 +145,7 @@ export const ko_KR: LanguageTranslation = {
                         change_schema: '스키마 변경',
                         add_field: '필드 추가',
                         add_index: '인덱스 추가',
+                        duplicate_table: 'Duplicate Table', // TODO: Translate
                         delete_table: '테이블 삭제',
                     },
                 },
@@ -369,6 +370,7 @@ export const ko_KR: LanguageTranslation = {
 
         table_node_context_menu: {
             edit_table: '테이블 수정',
+            duplicate_table: 'Duplicate table', // TODO: Translate
             delete_table: '테이블 삭제',
         },
 

--- a/src/i18n/locales/pt_BR.ts
+++ b/src/i18n/locales/pt_BR.ts
@@ -145,6 +145,7 @@ export const pt_BR: LanguageTranslation = {
                         change_schema: 'Alterar Esquema',
                         add_field: 'Adicionar Campo',
                         add_index: 'Adicionar Índice',
+                        duplicate_table: 'Duplicate Table', // TODO: Translate
                         delete_table: 'Excluir Tabela',
                     },
                 },
@@ -370,6 +371,7 @@ export const pt_BR: LanguageTranslation = {
 
         table_node_context_menu: {
             edit_table: 'Editar Tabela',
+            duplicate_table: 'Duplicate table', // TODO: Translate
             delete_table: 'Excluir Tabela',
         },
 

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -114,7 +114,7 @@ export const ru: LanguageTranslation = {
                 table: {
                     fields: 'Поля',
                     nullable: 'Может содержать NULL?',
-                    primary_key: 'Первичный ключ,',
+                    primary_key: 'Первичный ключ?',
                     indexes: 'Индексы',
                     comments: 'Комментарии',
                     no_comments: 'Нет комментария',
@@ -142,6 +142,7 @@ export const ru: LanguageTranslation = {
                         change_schema: 'Изменить схему',
                         add_field: 'Добавить поле',
                         add_index: 'Добавить индекс',
+                        duplicate_table: 'Создать копию таблицы',
                         delete_table: 'Удалить таблицу',
                     },
                 },
@@ -365,6 +366,7 @@ export const ru: LanguageTranslation = {
 
         table_node_context_menu: {
             edit_table: 'Изменить таблицу',
+            duplicate_table: 'Создать копию таблицы',
             delete_table: 'Удалить таблицу',
         },
 

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -145,6 +145,7 @@ export const uk: LanguageTranslation = {
                         change_schema: 'Змінити схему',
                         add_field: 'Додати поле',
                         add_index: 'Додати індекс',
+                        duplicate_table: 'Duplicate Table', // TODO: Translate
                         delete_table: 'Видалити таблицю',
                     },
                 },
@@ -370,6 +371,7 @@ export const uk: LanguageTranslation = {
 
         table_node_context_menu: {
             edit_table: 'Редагувати таблицю',
+            duplicate_table: 'Duplicate table', // TODO: Translate
             delete_table: 'Видалити таблицю',
         },
 

--- a/src/pages/editor-page/canvas/table-node/table-node-context-menu.tsx
+++ b/src/pages/editor-page/canvas/table-node/table-node-context-menu.tsx
@@ -18,18 +18,26 @@ export interface TableNodeContextMenuProps {
 export const TableNodeContextMenu: React.FC<
     React.PropsWithChildren<TableNodeContextMenuProps>
 > = ({ children, table }) => {
-    const { removeTable, readonly } = useChartDB();
+    // tableId is consciously extracted, to prevent relying on table object
+    // reference inside callbacks to prevent leaks. We actually watch only tableId in them
+    const tableId = table.id;
+
+    const { removeTable, readonly, duplicateTable } = useChartDB();
     const { openTableFromSidebar } = useLayout();
     const { t } = useTranslation();
     const { isMd: isDesktop } = useBreakpoint('md');
 
     const editTableHandler = useCallback(() => {
-        openTableFromSidebar(table.id);
-    }, [openTableFromSidebar, table.id]);
+        openTableFromSidebar(tableId);
+    }, [openTableFromSidebar, tableId]);
 
     const removeTableHandler = useCallback(() => {
-        removeTable(table.id);
-    }, [removeTable, table.id]);
+        removeTable(tableId);
+    }, [removeTable, tableId]);
+
+    const duplicateTableHandler = useCallback(() => {
+        duplicateTable(tableId);
+    }, [duplicateTable, tableId]);
 
     if (!isDesktop || readonly) {
         return <>{children}</>;
@@ -41,7 +49,13 @@ export const TableNodeContextMenu: React.FC<
                 <ContextMenuItem onClick={editTableHandler}>
                     {t('table_node_context_menu.edit_table')}
                 </ContextMenuItem>
-                <ContextMenuItem onClick={removeTableHandler}>
+                <ContextMenuItem onClick={duplicateTableHandler}>
+                    {t('table_node_context_menu.duplicate_table')}
+                </ContextMenuItem>
+                <ContextMenuItem
+                    className="text-red-700"
+                    onClick={removeTableHandler}
+                >
                     {t('table_node_context_menu.delete_table')}
                 </ContextMenuItem>
             </ContextMenuContent>

--- a/src/pages/editor-page/canvas/table-node/table-node.tsx
+++ b/src/pages/editor-page/canvas/table-node/table-node.tsx
@@ -126,6 +126,7 @@ export const TableNode: React.FC<NodeProps<TableNodeType>> = React.memo(
         }, [expanded, table.fields, isMustDisplayedField]);
 
         return (
+            // TODO?: replace the whole table reference with just tableId, because it's the only thing that's used inside
             <TableNodeContextMenu table={table}>
                 <div
                     className={cn(

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/useTableActionsDropdownClickHandlers.ts
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/useTableActionsDropdownClickHandlers.ts
@@ -1,0 +1,32 @@
+import { useChartDB } from '@/hooks/use-chartdb';
+import { useCallback } from 'react';
+
+export function useTableActionsDropdownClickHandlers(tableId: string) {
+    const { removeTable, createIndex, createField, duplicateTable } =
+        useChartDB();
+
+    const selectedMethods = {
+        createField,
+        createIndex,
+        duplicateTable,
+        removeTable,
+    };
+
+    return Object.fromEntries(
+        Object.entries(selectedMethods).map(([methodName, method]) => [
+            methodName,
+            // eslint-disable-next-line react-hooks/rules-of-hooks
+            useCallback(
+                (event) => {
+                    event.stopPropagation();
+                    method(tableId);
+                },
+                // eslint-disable-next-line react-hooks/exhaustive-deps
+                [tableId, method]
+            ),
+        ])
+    ) as Record<
+        keyof typeof selectedMethods,
+        React.MouseEventHandler<HTMLElement>
+    >;
+}


### PR DESCRIPTION
## Gives ability to duplicate table using simple button

| From canvas | From side-panel |
|---|---|
| ![Screenshot From 2024-11-10 01-37-35](https://github.com/user-attachments/assets/47e899a9-784a-4734-84cd-b6f95d0cbed7) | ![Screenshot From 2024-11-10 01-40-11](https://github.com/user-attachments/assets/b962c3d5-df0c-4579-a598-9b5c10c7f917) |

## New table will have the same reconstructed indexes and columns, as original table, but with new IDs and creationDates for everything: the table, it's columns, and it's indexes, which point to according IDs of freshly created columns.

|Source table showing first index | Source table showing second index|
|---|---|
| ![Screenshot From 2024-11-10 01-48-13](https://github.com/user-attachments/assets/bd166cbf-839a-40c7-8758-228446c5a5fc) | ![Screenshot From 2024-11-10 01-48-02](https://github.com/user-attachments/assets/69ab215c-bc86-4053-9d17-075683398d52) |

|Duplicated table showing first index | Duplicated table showing second index|
|---|---|
| ![Screenshot From 2024-11-10 01-48-40](https://github.com/user-attachments/assets/a8677d8b-d10b-489b-bfcd-914fc4db13f3) | ![Screenshot From 2024-11-10 01-48-49](https://github.com/user-attachments/assets/bdcc7538-1462-4e2b-af1b-c9e33d733244) |

## Pressing those buttons leads to creation of a table's copy nearby

![Screenshot From 2024-11-10 01-37-44](https://github.com/user-attachments/assets/96be29e1-92fe-416a-8d4f-d16657cd5504)

## Relationships with other tables are not preserved

![Screenshot From 2024-11-10 02-01-09](https://github.com/user-attachments/assets/e22f7fd9-b600-49b9-bf1b-6e75f3b6ac74)

![Screenshot From 2024-11-10 02-01-15](https://github.com/user-attachments/assets/4693db31-5a59-4eb1-aedf-07534cfc41b1)

