### PR TITLE
feat(side-panel): Add functionality of order tables by drag & drop

### DIFF
--- a/src/context/chartdb-context/chartdb-provider.tsx
+++ b/src/context/chartdb-context/chartdb-provider.tsx
@@ -311,7 +311,7 @@ export const ChartDBProvider: React.FC<
                 color: randomColor(),
                 createdAt: Date.now(),
                 isView: false,
-                order: 9999,
+                order: tables.length,
                 ...attributes,
             };
             await addTable(table);

--- a/src/context/chartdb-context/chartdb-provider.tsx
+++ b/src/context/chartdb-context/chartdb-provider.tsx
@@ -27,6 +27,7 @@ export interface ChartDBProviderProps {
     diagram?: Diagram;
     readonly?: boolean;
 }
+
 export const ChartDBProvider: React.FC<
     React.PropsWithChildren<ChartDBProviderProps>
 > = ({ children, diagram, readonly }) => {
@@ -310,6 +311,7 @@ export const ChartDBProvider: React.FC<
                 color: randomColor(),
                 createdAt: Date.now(),
                 isView: false,
+                order: 9999,
                 ...attributes,
             };
             await addTable(table);

--- a/src/context/storage-context/storage-provider.tsx
+++ b/src/context/storage-context/storage-provider.tsx
@@ -122,6 +122,18 @@ export const StorageProvider: React.FC<React.PropsWithChildren> = ({
         config: '++id, defaultDiagramId',
     });
 
+    db.version(8).stores({
+        diagrams:
+            '++id, name, databaseType, databaseEdition, createdAt, updatedAt',
+        db_tables:
+            '++id, diagramId, name, schema, x, y, fields, indexes, color, createdAt, width, comment, isView, isMaterializedView, order',
+        db_relationships:
+            '++id, diagramId, name, sourceSchema, sourceTableId, targetSchema, targetTableId, sourceFieldId, targetFieldId, type, createdAt',
+        db_dependencies:
+            '++id, diagramId, schema, tableId, dependentSchema, dependentTableId, createdAt',
+        config: '++id, defaultDiagramId',
+    });
+
     db.on('ready', async () => {
         const config = await getConfig();
 
@@ -345,15 +357,7 @@ export const StorageProvider: React.FC<React.PropsWithChildren> = ({
             .equals(diagramId)
             .toArray();
 
-        // Sort tables first alphabetically, then views alphabetically
-        return tables.sort((a, b) => {
-            if (a.isView === b.isView) {
-                // Both are either tables or views, so sort alphabetically by name
-                return a.name.localeCompare(b.name);
-            }
-            // If one is a view and the other is not, put tables first
-            return a.isView ? 1 : -1;
-        });
+        return tables;
     };
 
     const addRelationship: StorageContext['addRelationship'] = async ({

--- a/src/lib/domain/db-table.ts
+++ b/src/lib/domain/db-table.ts
@@ -40,7 +40,6 @@ export interface DBTable {
     createdAt: number;
     width?: number;
     comments?: string;
-    hidden?: boolean;
     order?: number;
 }
 

--- a/src/lib/domain/db-table.ts
+++ b/src/lib/domain/db-table.ts
@@ -41,6 +41,7 @@ export interface DBTable {
     width?: number;
     comments?: string;
     hidden?: boolean;
+    order?: number;
 }
 
 export const dbTableSchema: z.ZodType<DBTable> = z.object({
@@ -58,6 +59,7 @@ export const dbTableSchema: z.ZodType<DBTable> = z.object({
     width: z.number().optional(),
     comments: z.string().optional(),
     hidden: z.boolean().optional(),
+    order: z.number().optional(),
 });
 
 export const shouldShowTablesBySchemaFilter = (

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-content/table-field/table-field.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-content/table-field/table-field.tsx
@@ -48,7 +48,7 @@ export const TableField: React.FC<TableFieldProps> = ({
     }));
 
     const style = {
-        transform: CSS.Transform.toString(transform),
+        transform: CSS.Translate.toString(transform),
         transition,
     };
 

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/table-list-item-header.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/table-list-item-header.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import {
     CircleDotDashed,
+    GripVertical,
     Pencil,
     EllipsisVertical,
     Trash2,
@@ -15,6 +16,7 @@ import type { DBTable } from '@/lib/domain/db-table';
 import { Input } from '@/components/input/input';
 import { useChartDB } from '@/hooks/use-chartdb';
 import { useClickAway, useKeyPressEvent } from 'react-use';
+import { useSortable } from '@dnd-kit/sortable';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -60,6 +62,7 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
     const [tableName, setTableName] = React.useState(table.name);
     const { isMd: isDesktop } = useBreakpoint('md');
     const inputRef = React.useRef<HTMLInputElement>(null);
+    const { listeners } = useSortable({ id: table.id });
 
     const editTableName = useCallback(() => {
         if (!editMode) return;
@@ -252,6 +255,12 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
 
     return (
         <div className="group flex h-11 flex-1 items-center justify-between gap-1 overflow-hidden">
+            <div
+                className="flex cursor-move items-center justify-center"
+                {...listeners}
+            >
+                <GripVertical className="size-4 text-muted-foreground" />
+            </div>
             <div className="flex min-w-0 flex-1 px-1">
                 {editMode ? (
                     <Input

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item.tsx
@@ -7,6 +7,8 @@ import {
 import { TableListItemHeader } from './table-list-item-header/table-list-item-header';
 import { TableListItemContent } from './table-list-item-content/table-list-item-content';
 import type { DBTable } from '@/lib/domain/db-table';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
 export interface TableListItemProps {
     table: DBTable;
@@ -16,20 +18,35 @@ export const TableListItem = React.forwardRef<
     React.ElementRef<typeof AccordionItem>,
     TableListItemProps
 >(({ table }, ref) => {
+    const { attributes, setNodeRef, transform, transition } = useSortable({
+        id: table.id,
+    });
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
+
     return (
         <AccordionItem value={table.id} className="rounded-md" ref={ref}>
-            <AccordionTrigger
-                className="w-full rounded-md border-l-[6px] px-2 py-0 hover:bg-accent hover:no-underline data-[state=open]:rounded-b-none"
-                style={{
-                    borderColor: table.color,
-                }}
-                asChild
+            <div
+                className="w-full"
+                ref={setNodeRef}
+                style={style}
+                {...attributes}
             >
-                <TableListItemHeader table={table} />
-            </AccordionTrigger>
-            <AccordionContent>
-                <TableListItemContent table={table} />
-            </AccordionContent>
+                <AccordionTrigger
+                    className="w-full rounded-md border-l-[6px] px-2 py-0 hover:bg-accent hover:no-underline data-[state=open]:rounded-b-none"
+                    style={{
+                        borderColor: table.color,
+                    }}
+                    asChild
+                >
+                    <TableListItemHeader table={table} />
+                </AccordionTrigger>
+                <AccordionContent>
+                    <TableListItemContent table={table} />
+                </AccordionContent>
+            </div>
         </AccordionItem>
     );
 });

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item.tsx
@@ -8,11 +8,22 @@ import { TableListItemHeader } from './table-list-item-header/table-list-item-he
 import { TableListItemContent } from './table-list-item-content/table-list-item-content';
 import type { DBTable } from '@/lib/domain/db-table';
 import { useSortable } from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
+import type { Transform } from '@dnd-kit/utilities';
 
 export interface TableListItemProps {
     table: DBTable;
 }
+
+const collectTransform = (transform: Transform | null): string => {
+    if (transform == null) {
+        return '';
+    }
+
+    const defaultScaleX: string = 'scaleX(1)';
+    const defaultScaleY: string = 'scaleY(1)';
+
+    return `translate3d(${transform.x}px, ${transform.y}px, 0px) ${defaultScaleX} ${defaultScaleY}`;
+};
 
 export const TableListItem = React.forwardRef<
     React.ElementRef<typeof AccordionItem>,
@@ -22,7 +33,7 @@ export const TableListItem = React.forwardRef<
         id: table.id,
     });
     const style = {
-        transform: CSS.Transform.toString(transform),
+        transform: collectTransform(transform),
         transition,
     };
 

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item.tsx
@@ -8,22 +8,11 @@ import { TableListItemHeader } from './table-list-item-header/table-list-item-he
 import { TableListItemContent } from './table-list-item-content/table-list-item-content';
 import type { DBTable } from '@/lib/domain/db-table';
 import { useSortable } from '@dnd-kit/sortable';
-import type { Transform } from '@dnd-kit/utilities';
+import { CSS } from '@dnd-kit/utilities';
 
 export interface TableListItemProps {
     table: DBTable;
 }
-
-const collectTransform = (transform: Transform | null): string => {
-    if (transform == null) {
-        return '';
-    }
-
-    const defaultScaleX: string = 'scaleX(1)';
-    const defaultScaleY: string = 'scaleY(1)';
-
-    return `translate3d(${transform.x}px, ${transform.y}px, 0px) ${defaultScaleX} ${defaultScaleY}`;
-};
 
 export const TableListItem = React.forwardRef<
     React.ElementRef<typeof AccordionItem>,
@@ -33,14 +22,14 @@ export const TableListItem = React.forwardRef<
         id: table.id,
     });
     const style = {
-        transform: collectTransform(transform),
+        transform: CSS.Translate.toString(transform),
         transition,
     };
 
     return (
-        <AccordionItem value={table.id} className="rounded-md" ref={ref}>
+        <AccordionItem value={table.id} className="border-none" ref={ref}>
             <div
-                className="w-full"
+                className="w-full rounded-md border-b"
                 ref={setNodeRef}
                 style={style}
                 {...attributes}

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list.tsx
@@ -3,12 +3,28 @@ import { Accordion } from '@/components/accordion/accordion';
 import { TableListItem } from './table-list-item/table-list-item';
 import type { DBTable } from '@/lib/domain/db-table';
 import { useLayout } from '@/hooks/use-layout';
+import {
+    closestCenter,
+    DndContext,
+    type DragEndEvent,
+    PointerSensor,
+    useSensor,
+    useSensors,
+} from '@dnd-kit/core';
+import {
+    arrayMove,
+    SortableContext,
+    verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { useChartDB } from '@/hooks/use-chartdb.ts';
 
 export interface TableListProps {
     tables: DBTable[];
 }
 
 export const TableList: React.FC<TableListProps> = ({ tables }) => {
+    const { updateTablesState } = useChartDB();
+
     const { openTableFromSidebar, openedTableInSidebar } = useLayout();
     const lastOpenedTable = React.useRef<string | null>(null);
     const refs = useMemo(
@@ -32,6 +48,49 @@ export const TableList: React.FC<TableListProps> = ({ tables }) => {
         [refs]
     );
 
+    const sensors = useSensors(useSensor(PointerSensor));
+
+    const handleDragEnd = (event: DragEndEvent) => {
+        const { active, over } = event;
+
+        if (active?.id !== over?.id && !!over && !!active) {
+            const oldIndex = tables.findIndex(
+                (table) => table.id === active.id
+            );
+            const newIndex = tables.findIndex((table) => table.id === over.id);
+
+            const orderingTables: DBTable[] = arrayMove<DBTable>(
+                tables,
+                oldIndex,
+                newIndex
+            );
+
+            updateTablesState((currentTables: DBTable[]) =>
+                currentTables.map((currentTable: DBTable) => {
+                    let currentIndex: number = -1;
+
+                    for (let i = 0; i < orderingTables.length; i++) {
+                        const updatedTable: DBTable | undefined =
+                            orderingTables[i];
+
+                        if (
+                            updatedTable &&
+                            updatedTable.id === currentTable.id
+                        ) {
+                            currentIndex = i;
+                        }
+                    }
+
+                    if (currentIndex != -1) {
+                        currentTable.order = currentIndex;
+                    }
+
+                    return currentTable;
+                })
+            );
+        }
+    };
+
     const handleScrollToTable = useCallback(() => {
         if (
             openedTableInSidebar &&
@@ -51,13 +110,28 @@ export const TableList: React.FC<TableListProps> = ({ tables }) => {
             onValueChange={openTableFromSidebar}
             onAnimationEnd={handleScrollToTable}
         >
-            {tables.map((table) => (
-                <TableListItem
-                    key={table.id}
-                    table={table}
-                    ref={refs[table.id]}
-                />
-            ))}
+            <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+            >
+                <SortableContext
+                    items={tables}
+                    strategy={verticalListSortingStrategy}
+                >
+                    {tables
+                        .sort((table1: DBTable, table2: DBTable) => {
+                            return (table1.order ?? 0) - (table2.order ?? 0);
+                        })
+                        .map((table) => (
+                            <TableListItem
+                                key={table.id}
+                                table={table}
+                                ref={refs[table.id]}
+                            />
+                        ))}
+                </SortableContext>
+            </DndContext>
         </Accordion>
     );
 };


### PR DESCRIPTION
This PR solves the following issue #393.

Reorder tables.

Mechanism:
1) When creating a new table, the `order` parameter is assigned the value `9999`.
2) When moving any table to a new position, all other tables change their index depending on the moved table.

The following functions have been tested:
1) Exporting the database to a JSON file
2) Importing a database from a JSON file

Preview:

![preview_0](https://github.com/user-attachments/assets/8966c616-d4c5-452d-9607-75ebc310b349)

![preview_1](https://github.com/user-attachments/assets/c9513bcf-00df-42dd-b3cd-0460463cdfba)

![preview_2](https://github.com/user-attachments/assets/d5df50bc-5c16-4bcc-86b3-22a09565f77e)