### PR TITLE
Update Docker Instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ docker build -t chartdb . (If you want AI capabilities, use `docker build --buil
 docker run -p 8080:80 chartdb
 ```
 
-
 Open your browser and navigate to `http://localhost:8080`.
 
 ## Try it on our website

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ VITE_OPENAI_API_KEY=<YOUR_OPEN_AI_KEY> npm run build
 docker run -e OPENAI_API_KEY=<YOUR_OPEN_AI_KEY> -p 8080:80 ghcr.io/chartdb/chartdb:latest
 ```
 
-#### Build & run Docker Image locally
+#### Build & run Docker image locally
 ```bash
 docker build -t chartdb . (If you want AI capabilities, use `docker build --build-arg VITE_OPENAI_API_KEY=<YOUR_OPEN_AI_KEY> -t chartdb .`)
 docker run -p 8080:80 chartdb

--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ docker build -t chartdb . (If you want AI capabilities, use `docker build --buil
 docker run -p 8080:80 chartdb
 ```
 
+#### Run locally from GitHub Container Registry
+```bash
+docker run -p 8080:80 --rm -it ghcr.io/chartdb/chartdb:latest
+```
+
 Open your browser and navigate to `http://localhost:8080`.
 
 ## Try it on our website

--- a/README.md
+++ b/README.md
@@ -96,16 +96,16 @@ VITE_OPENAI_API_KEY=<YOUR_OPEN_AI_KEY> npm run build
 ```
 
 ### Running the Docker Container
+```bash
+docker run -e OPENAI_API_KEY=<YOUR_OPEN_AI_KEY> -p 8080:80 ghcr.io/chartdb/chartdb:latest
+```
 
+#### Build & run Docker Image locally
 ```bash
 docker build -t chartdb . (If you want AI capabilities, use `docker build --build-arg VITE_OPENAI_API_KEY=<YOUR_OPEN_AI_KEY> -t chartdb .`)
 docker run -p 8080:80 chartdb
 ```
 
-#### Run locally from GitHub Container Registry
-```bash
-docker run -p 8080:80 --rm -it ghcr.io/chartdb/chartdb:latest
-```
 
 Open your browser and navigate to `http://localhost:8080`.
 


### PR DESCRIPTION
Add section for running Docker container locally direct from GitHub's Container Registry image as published by project's GitHub Actions workflow. 

During discussion in discord, it was revealed that there are container images published and this extra snippet shows a way to leverage them.