### PR TITLE
feat(mariadb): Add uuid data type

### DIFF
--- a/src/lib/data/data-types/mariadb-data-types.ts
+++ b/src/lib/data/data-types/mariadb-data-types.ts
@@ -50,4 +50,5 @@ export const mariadbDataTypes: readonly DataType[] = [
 
     // JSON Type
     { name: 'json', id: 'json' },
+    { name: 'uuid', id: 'uuid' },
 ] as const;


### PR DESCRIPTION
Madiadb is missing the UUID data type ([https://mariadb.com/kb/en/uuid-data-type/](https://mariadb.com/kb/en/uuid-data-type/)). I simply added it in `src/lib/data/data-types/mariadb-data-types.ts`