### PR TITLE
feat(view-menu): add toggle for mini map visibility (#496)

### DIFF
--- a/src/context/local-config-context/local-config-context.tsx
+++ b/src/context/local-config-context/local-config-context.tsx
@@ -38,6 +38,9 @@ export interface LocalConfigContext {
 
     showDependenciesOnCanvas: boolean;
     setShowDependenciesOnCanvas: (showDependenciesOnCanvas: boolean) => void;
+
+    showMiniMapOnCanvas: boolean;
+    setShowMiniMapOnCanvas: (showMiniMapOnCanvas: boolean) => void;
 }
 
 export const LocalConfigContext = createContext<LocalConfigContext>({
@@ -70,4 +73,7 @@ export const LocalConfigContext = createContext<LocalConfigContext>({
 
     showDependenciesOnCanvas: false,
     setShowDependenciesOnCanvas: emptyFn,
+
+    showMiniMapOnCanvas: false,
+    setShowMiniMapOnCanvas: emptyFn,
 });

--- a/src/context/local-config-context/local-config-provider.tsx
+++ b/src/context/local-config-context/local-config-provider.tsx
@@ -13,6 +13,7 @@ const starUsDialogLastOpenKey = 'star_us_dialog_last_open';
 const buckleWaitlistOpenedKey = 'buckle_waitlist_opened';
 const buckleDialogLastOpenKey = 'buckle_dialog_last_open';
 const showDependenciesOnCanvasKey = 'show_dependencies_on_canvas';
+const showMiniMapOnCanvasKey = 'show_minimap_on_canvas';
 
 export const LocalConfigProvider: React.FC<React.PropsWithChildren> = ({
     children,
@@ -65,6 +66,11 @@ export const LocalConfigProvider: React.FC<React.PropsWithChildren> = ({
         React.useState<boolean>(
             (localStorage.getItem(showDependenciesOnCanvasKey) || 'false') ===
                 'true'
+        );
+
+    const [showMiniMapOnCanvas, setShowMiniMapOnCanvas] =
+        React.useState<boolean>(
+            (localStorage.getItem(showMiniMapOnCanvasKey) || 'true') === 'true'
         );
 
     useEffect(() => {
@@ -122,6 +128,13 @@ export const LocalConfigProvider: React.FC<React.PropsWithChildren> = ({
         );
     }, [showDependenciesOnCanvas]);
 
+    useEffect(() => {
+        localStorage.setItem(
+            showMiniMapOnCanvasKey,
+            showMiniMapOnCanvas.toString()
+        );
+    }, [showMiniMapOnCanvas]);
+
     return (
         <LocalConfigContext.Provider
             value={{
@@ -145,6 +158,8 @@ export const LocalConfigProvider: React.FC<React.PropsWithChildren> = ({
                 buckleDialogLastOpen,
                 buckleWaitlistOpened,
                 setBuckleWaitlistOpened,
+                showMiniMapOnCanvas,
+                setShowMiniMapOnCanvas,
             }}
         >
             {children}

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -30,6 +30,9 @@ export const ar: LanguageTranslation = {
                 theme: 'المظهر',
                 show_dependencies: 'إظهار الاعتمادات',
                 hide_dependencies: 'إخفاء الاعتمادات',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             share: {
                 share: 'مشاركة',

--- a/src/i18n/locales/bn.ts
+++ b/src/i18n/locales/bn.ts
@@ -30,6 +30,9 @@ export const bn: LanguageTranslation = {
                 theme: 'থিম',
                 show_dependencies: 'নির্ভরতাগুলি দেখান',
                 hide_dependencies: 'নির্ভরতাগুলি লুকান',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
 
             share: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -30,6 +30,9 @@ export const de: LanguageTranslation = {
                 theme: 'Stil',
                 show_dependencies: 'Abhängigkeiten anzeigen',
                 hide_dependencies: 'Abhängigkeiten ausblenden',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             // TODO: Translate
             share: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -30,6 +30,8 @@ export const en = {
                 theme: 'Theme',
                 show_dependencies: 'Show Dependencies',
                 hide_dependencies: 'Hide Dependencies',
+                show_minimap: 'Show MiniMap',
+                hide_minimap: 'Hide MiniMap',
             },
             share: {
                 share: 'Share',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -30,8 +30,8 @@ export const en = {
                 theme: 'Theme',
                 show_dependencies: 'Show Dependencies',
                 hide_dependencies: 'Hide Dependencies',
-                show_minimap: 'Show MiniMap',
-                hide_minimap: 'Hide MiniMap',
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             share: {
                 share: 'Share',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -30,6 +30,9 @@ export const es: LanguageTranslation = {
                 theme: 'Tema',
                 show_dependencies: 'Mostrar dependencias',
                 hide_dependencies: 'Ocultar dependencias',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             // TODO: Translate
             share: {

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -30,6 +30,9 @@ export const fr: LanguageTranslation = {
                 theme: 'Thème',
                 show_dependencies: 'Afficher les Dépendances',
                 hide_dependencies: 'Masquer les Dépendances',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             share: {
                 share: 'Partage',

--- a/src/i18n/locales/gu.ts
+++ b/src/i18n/locales/gu.ts
@@ -30,6 +30,9 @@ export const gu: LanguageTranslation = {
                 theme: 'થિમ',
                 show_dependencies: 'નિર્ભરતાઓ બતાવો',
                 hide_dependencies: 'નિર્ભરતાઓ છુપાવો',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
 
             share: {

--- a/src/i18n/locales/hi.ts
+++ b/src/i18n/locales/hi.ts
@@ -30,6 +30,9 @@ export const hi: LanguageTranslation = {
                 theme: 'थीम',
                 show_dependencies: 'निर्भरता दिखाएँ',
                 hide_dependencies: 'निर्भरता छिपाएँ',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             // TODO: Translate
             share: {

--- a/src/i18n/locales/id_ID.ts
+++ b/src/i18n/locales/id_ID.ts
@@ -30,6 +30,9 @@ export const id_ID: LanguageTranslation = {
                 theme: 'Tema',
                 show_dependencies: 'Tampilkan Dependensi',
                 hide_dependencies: 'Sembunyikan Dependensi',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             share: {
                 share: 'Bagikan',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -31,6 +31,9 @@ export const ja: LanguageTranslation = {
                 // TODO: Translate
                 show_dependencies: 'Show Dependencies',
                 hide_dependencies: 'Hide Dependencies',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             // TODO: Translate
             share: {

--- a/src/i18n/locales/ko_KR.ts
+++ b/src/i18n/locales/ko_KR.ts
@@ -30,6 +30,9 @@ export const ko_KR: LanguageTranslation = {
                 theme: '테마',
                 show_dependencies: '종속성 보이기',
                 hide_dependencies: '종속성 숨기기',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             share: {
                 share: '공유',

--- a/src/i18n/locales/mr.ts
+++ b/src/i18n/locales/mr.ts
@@ -30,6 +30,9 @@ export const mr: LanguageTranslation = {
                 theme: 'थीम',
                 show_dependencies: 'डिपेंडेन्सि दाखवा',
                 hide_dependencies: 'डिपेंडेन्सि लपवा',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             share: {
                 // TODO: Add translations

--- a/src/i18n/locales/ne.ts
+++ b/src/i18n/locales/ne.ts
@@ -30,6 +30,9 @@ export const ne: LanguageTranslation = {
                 theme: 'थिम',
                 show_dependencies: 'डिपेन्डेन्सीहरू देखाउनुहोस्',
                 hide_dependencies: 'डिपेन्डेन्सीहरू लुकाउनुहोस्',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             share: {
                 share: 'शेयर गर्नुहोस्',

--- a/src/i18n/locales/pt_BR.ts
+++ b/src/i18n/locales/pt_BR.ts
@@ -30,6 +30,9 @@ export const pt_BR: LanguageTranslation = {
                 theme: 'Tema',
                 show_dependencies: 'Mostrar Dependências',
                 hide_dependencies: 'Ocultar Dependências',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             // TODO: Translate
             share: {

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -30,6 +30,9 @@ export const ru: LanguageTranslation = {
                 theme: 'Тема',
                 show_dependencies: 'Показать зависимости',
                 hide_dependencies: 'Скрыть зависимости',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             share: {
                 share: 'Поделиться',

--- a/src/i18n/locales/te.ts
+++ b/src/i18n/locales/te.ts
@@ -30,6 +30,9 @@ export const te: LanguageTranslation = {
                 theme: 'థీమ్',
                 show_dependencies: 'ఆధారాలు చూపించండి',
                 hide_dependencies: 'ఆధారాలను దాచండి',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             // TODO: Translate
             share: {

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -30,6 +30,9 @@ export const tr: LanguageTranslation = {
                 theme: 'Tema',
                 show_dependencies: 'Bağımlılıkları Göster',
                 hide_dependencies: 'Bağımlılıkları Gizle',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             // TODO: Translate
             share: {

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -30,6 +30,9 @@ export const uk: LanguageTranslation = {
                 theme: 'Тема',
                 show_dependencies: 'Показати залежності',
                 hide_dependencies: 'Приховати залежності',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             // TODO: Translate
             share: {

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -30,6 +30,9 @@ export const vi: LanguageTranslation = {
                 theme: 'Chủ đề',
                 show_dependencies: 'Hiển thị các phụ thuộc',
                 hide_dependencies: 'Ẩn các phụ thuộc',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             share: {
                 share: 'Chia sẻ',

--- a/src/i18n/locales/zh_CN.ts
+++ b/src/i18n/locales/zh_CN.ts
@@ -30,6 +30,9 @@ export const zh_CN: LanguageTranslation = {
                 theme: '主题',
                 show_dependencies: '展示依赖',
                 hide_dependencies: '隐藏依赖',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             share: {
                 share: '分享',

--- a/src/i18n/locales/zh_TW.ts
+++ b/src/i18n/locales/zh_TW.ts
@@ -30,6 +30,9 @@ export const zh_TW: LanguageTranslation = {
                 theme: '主題',
                 show_dependencies: '顯示相依性',
                 hide_dependencies: '隱藏相依性',
+                // TODO: Translate
+                show_minimap: 'Show Mini Map',
+                hide_minimap: 'Hide Mini Map',
             },
             share: {
                 share: '分享',

--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -133,7 +133,8 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables, readonly }) => {
     } = useChartDB();
     const { showSidePanel } = useLayout();
     const { effectiveTheme } = useTheme();
-    const { scrollAction, showDependenciesOnCanvas } = useLocalConfig();
+    const { scrollAction, showDependenciesOnCanvas, showMiniMapOnCanvas } =
+        useLocalConfig();
     const { showAlert } = useAlert();
     const { isMd: isDesktop } = useBreakpoint('md');
     const nodeTypes = useMemo(() => ({ table: TableNode }), []);
@@ -228,6 +229,7 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables, readonly }) => {
         dependencies,
         setEdges,
         showDependenciesOnCanvas,
+        showMiniMapOnCanvas,
         databaseType,
     ]);
 
@@ -871,12 +873,14 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables, readonly }) => {
                     >
                         <Toolbar readonly={readonly} />
                     </Controls>
-                    <MiniMap
-                        style={{
-                            width: isDesktop ? 100 : 60,
-                            height: isDesktop ? 100 : 60,
-                        }}
-                    />
+                    {showMiniMapOnCanvas && (
+                        <MiniMap
+                            style={{
+                                width: isDesktop ? 100 : 60,
+                                height: isDesktop ? 100 : 60,
+                            }}
+                        />
+                    )}
                     <Background
                         variant={BackgroundVariant.Dots}
                         gap={16}

--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -874,7 +874,6 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables, readonly }) => {
                     </Controls>
                     {showMiniMapOnCanvas && (
                         <MiniMap
-                        
                             style={{
                                 width: isDesktop ? 100 : 60,
                                 height: isDesktop ? 100 : 60,

--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -229,7 +229,6 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables, readonly }) => {
         dependencies,
         setEdges,
         showDependenciesOnCanvas,
-        showMiniMapOnCanvas,
         databaseType,
     ]);
 
@@ -875,6 +874,7 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables, readonly }) => {
                     </Controls>
                     {showMiniMapOnCanvas && (
                         <MiniMap
+                        
                             style={{
                                 width: isDesktop ? 100 : 60,
                                 height: isDesktop ? 100 : 60,

--- a/src/pages/editor-page/top-navbar/top-navbar.tsx
+++ b/src/pages/editor-page/top-navbar/top-navbar.tsx
@@ -65,6 +65,8 @@ export const TopNavbar: React.FC<TopNavbarProps> = () => {
         showCardinality,
         setShowDependenciesOnCanvas,
         showDependenciesOnCanvas,
+        setShowMiniMapOnCanvas,
+        showMiniMapOnCanvas,
     } = useLocalConfig();
     const { effectiveTheme } = useTheme();
     const { t } = useTranslation();
@@ -204,6 +206,10 @@ export const TopNavbar: React.FC<TopNavbarProps> = () => {
     const openBuckleWaitlist = useCallback(() => {
         window.open('https://waitlist.buckle.dev', '_blank');
     }, []);
+
+    const showOrHideMiniMap = useCallback(() => {
+        setShowMiniMapOnCanvas(!showMiniMapOnCanvas);
+    }, [showMiniMapOnCanvas, setShowMiniMapOnCanvas]);
 
     const renderGetBuckleButton = useCallback(() => {
         return (
@@ -512,6 +518,12 @@ export const TopNavbar: React.FC<TopNavbarProps> = () => {
                                         : t('menu.view.show_dependencies')}
                                 </MenubarItem>
                             ) : null}
+
+                            <MenubarItem onClick={showOrHideMiniMap}>
+                                {showMiniMapOnCanvas
+                                    ? t('menu.view.hide_minimap')
+                                    : t('menu.view.show_minimap')}
+                            </MenubarItem>
                             <MenubarSeparator />
                             <MenubarSub>
                                 <MenubarSubTrigger>


### PR DESCRIPTION
This PR fixes #496

## Summary
This pull request adds functionality to toggle the visibility of the MiniMap on the canvas via the "View" menu.

## Changes Implemented

### 1. New Context and State:

- Added `showMiniMapOnCanvas` and `setShowMiniMapOnCanvas` to the `LocalConfigContext` and `LocalConfigProvider`.
- Used `localStorage` to persist the MiniMap visibility setting across sessions.

### 2. Canvas Component:

- Updated the `Canvas` component to conditionally render the MiniMap based on the `showMiniMapOnCanvas` state.

### 3. Top Navbar:

- Added a new menu item to the "View" menu for toggling the MiniMap.

### 4. Localization:

- Added English translations for "Show MiniMap" and "Hide MiniMap" in the `en.ts` file.
- **Note:** I can add translations for other languages using online sources, but they may not be entirely accurate. I recommend having specialized contributors handle these translations for better quality and consistency.
