### PR TITLE
Update PSQL script to create output.json

### DIFF
--- a/src/lib/data/import-metadata/scripts/postgres-script.ts
+++ b/src/lib/data/import-metadata/scripts/postgres-script.ts
@@ -275,7 +275,7 @@ FROM fk_info${databaseEdition ? '_' + databaseEdition : ''}, pk_info, cols, inde
     if (options.databaseClient === DatabaseClient.POSTGRESQL_PSQL) {
         return `${psqlPreCommand}psql -h HOST_NAME -p PORT -U USER_NAME -d DATABASE_NAME -c "
 ${query.replace(/"/g, '\\"').replace(/\\\\/g, '\\\\\\').replace(/\\x/g, '\\\\x')}
-" -t -A | pbcopy; LG='\\033[0;32m'; NC='\\033[0m'; echo "You got the resultset ($(pbpaste | wc -c | xargs) characters) in Copy/Paste. \${LG}Go back & paste in ChartDB :)\${NC}";`;
+" -t -A > output.json";`;
     }
 
     return query;


### PR DESCRIPTION
Updating the PostgreSQL script so that the `psql` script creates an output.json with the result instead of using Mac-specific commands.