### PR TITLE
fix(Image Export): importing css rules error while download image

### DIFF
--- a/src/context/export-image-context/export-image-provider.tsx
+++ b/src/context/export-image-context/export-image-provider.tsx
@@ -166,6 +166,7 @@ export const ExportImageProvider: React.FC<React.PropsWithChildren> = ({
                         },
                         quality: 1,
                         pixelRatio: scale,
+                        skipFonts: true,
                     });
 
                     downloadImage(dataUrl, type);


### PR DESCRIPTION
Problem:
There was an error importing CSS rules while downloading the image. The html-to-image package was attempting to import fonts from [Google Fonts](https://fonts.googleapis.com/).

Solution:
I added the configuration skipFonts: true to the toPng function. This resolved the issue. In the resulting image, there were no font-related problems. The fonts in the image matched those in the HTML. It seems the image doesn’t actually require those fonts, but the package tries to download them anyway.