### PR TITLE
Fit all tables while exporting as image

### DIFF
--- a/src/context/export-image-context/export-image-provider.tsx
+++ b/src/context/export-image-context/export-image-provider.tsx
@@ -166,6 +166,7 @@ export const ExportImageProvider: React.FC<React.PropsWithChildren> = ({
                         },
                         quality: 1,
                         pixelRatio: scale,
+                        skipFonts: true,
                     });
 
                     downloadImage(dataUrl, type);

--- a/src/context/export-image-context/export-image-provider.tsx
+++ b/src/context/export-image-context/export-image-provider.tsx
@@ -11,7 +11,7 @@ export const ExportImageProvider: React.FC<React.PropsWithChildren> = ({
     children,
 }) => {
     const { hideLoader, showLoader } = useFullScreenLoader();
-    const { setNodes, getViewport } = useReactFlow();
+    const { setNodes, getViewport, fitView,  setViewport } = useReactFlow();
     const { effectiveTheme } = useTheme();
     const { diagramName } = useChartDB();
 
@@ -47,7 +47,22 @@ export const ExportImageProvider: React.FC<React.PropsWithChildren> = ({
                 nodes.map((node) => ({ ...node, selected: false }))
             );
 
+            const previousViewport = getViewport();  
+            
+            await fitView({
+                duration: 0,
+                padding: 0.1,
+                maxZoom: 0.8,
+            });
+
             const viewport = getViewport();
+            
+            setViewport({
+                x: previousViewport.x,
+                y: previousViewport.y,
+                zoom: previousViewport.zoom,
+            });
+            
             const reactFlowBounds = document
                 .querySelector('.react-flow')
                 ?.getBoundingClientRect();


### PR DESCRIPTION
Problem:
#516

Solved by:
Getting the ideally fitted viewport of the canvas, switching back to the old state immediately, and working with the ideally fitted viewport. 