### PR TITLE
feat: add support for custom inference servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:22-alpine AS builder
 
 ARG VITE_OPENAI_API_KEY
+ARG VITE_OPENAI_API_ENDPOINT
+ARG VITE_LLM_MODEL_NAME
 
 WORKDIR /usr/src/app
 
@@ -10,9 +12,12 @@ RUN npm ci
 
 COPY . .
 
+RUN echo "VITE_OPENAI_API_KEY=${VITE_OPENAI_API_KEY}" > .env && \
+    echo "VITE_OPENAI_API_ENDPOINT=${VITE_OPENAI_API_ENDPOINT}" >> .env && \
+    echo "VITE_LLM_MODEL_NAME=${VITE_LLM_MODEL_NAME}" >> .env
+
 RUN npm run build
 
-# Use a lightweight web server to serve the production build
 FROM nginx:stable-alpine AS production
 
 COPY --from=builder /usr/src/app/dist /usr/share/nginx/html
@@ -20,7 +25,6 @@ COPY ./default.conf.template /etc/nginx/conf.d/default.conf.template
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Expose the default port for the Nginx web server
 EXPOSE 80
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -45,17 +45,20 @@
 ### 🎉 ChartDB
 
 ChartDB is a powerful, web-based database diagramming editor.
+
 Instantly visualize your database schema with a single **"Smart Query."** Customize diagrams, export SQL scripts, and access all features—no account required. Experience seamless database design here.
 
 **What it does**:
 
--   **Instant Schema Import**
-    Run a single query to instantly retrieve your database schema as JSON. This makes it incredibly fast to visualize your database schema, whether for documentation, team discussions, or simply understanding your data better.
+- **Instant Schema Import**
 
--   **AI-Powered Export for Easy Migration**
-    Our AI-driven export feature allows you to generate the DDL script in the dialect of your choice. Whether you’re migrating from MySQL to PostgreSQL or from SQLite to MariaDB, ChartDB simplifies the process by providing the necessary scripts tailored to your target database.
--   **Interactive Editing**
-    Fine-tune your database schema using our intuitive editor. Easily make adjustments or annotations to better visualize complex structures.
+  Run a single query to instantly retrieve your database schema as JSON. This makes it incredibly fast to visualize your database schema, whether for documentation, team discussions, or simply understanding your data better.
+- **AI-Powered Export for Easy Migration**
+
+  Our AI-driven export feature allows you to generate the DDL script in the dialect of your choice. Whether you’re migrating from MySQL to PostgreSQL or from SQLite to MariaDB, ChartDB simplifies the process by providing the necessary scripts tailored to your target database.
+- **Interactive Editing**
+
+  Fine-tune your database schema using our intuitive editor. Easily make adjustments or annotations to better visualize complex structures.
 
 ### Status
 
@@ -63,13 +66,13 @@ ChartDB is currently in Public Beta. Star and watch this repository to get notif
 
 ### Supported Databases
 
--   ✅ PostgreSQL (<img src="./src/assets/postgresql_logo_2.png" width="15"/> + <img src="./src/assets/supabase.png" alt="Supabase" width="15"/> + <img src="./src/assets/timescale.png" alt="Timescale" width="15"/> )
--   ✅ MySQL
--   ✅ SQL Server
--   ✅ MariaDB
--   ✅ SQLite
--   ✅ CockroachDB
--   ✅ ClickHouse
+- ✅ PostgreSQL (<img src="./src/assets/postgresql_logo_2.png" width="15"/> + <img src="./src/assets/supabase.png" alt="Supabase" width="15"/> + <img src="./src/assets/timescale.png" alt="Timescale" width="15"/> )
+- ✅ MySQL
+- ✅ SQL Server
+- ✅ MariaDB
+- ✅ SQLite
+- ✅ CockroachDB
+- ✅ ClickHouse
 
 ## Getting Started
 
@@ -89,25 +92,67 @@ npm install
 npm run build
 ```
 
-Or like this if you want to have AI capabilities:
+### AI Capabilities Configuration
 
-```
+You have two options for enabling AI capabilities:
+
+#### Option 1: Using OpenAI API
+
+```bash
 npm install
 VITE_OPENAI_API_KEY=<YOUR_OPEN_AI_KEY> npm run build
 ```
 
+#### Option 2: Using Custom Inference Server
+
+```bash
+npm install
+VITE_OPENAI_API_ENDPOINT=<YOUR_ENDPOINT> VITE_LLM_MODEL_NAME=<YOUR_MODEL_NAME> npm run build
+```
+
 ### Run the Docker Container
+
+#### Using OpenAI API
+
 ```bash
 docker run -e OPENAI_API_KEY=<YOUR_OPEN_AI_KEY> -p 8080:80 ghcr.io/chartdb/chartdb:latest
 ```
 
-#### Build and Run locally
+### Build and Run Locally
+
+#### Using OpenAI API
+
 ```bash
 docker build -t chartdb .
 docker run -e OPENAI_API_KEY=<YOUR_OPEN_AI_KEY> -p 8080:80 chartdb
 ```
 
+#### Using Custom Inference Server
+
+```bash
+# Build
+docker build \
+  --build-arg VITE_OPENAI_API_ENDPOINT=<YOUR_ENDPOINT> \
+  --build-arg VITE_LLM_MODEL_NAME=<YOUR_MODEL_NAME> \
+  -t chartdb .
+
+# Run
+docker run \
+  -e OPENAI_API_ENDPOINT=<YOUR_ENDPOINT> \
+  -e LLM_MODEL_NAME=<YOUR_MODEL_NAME> \
+  -p 8080:80 chartdb
+```
+
+> **Note:** You must configure either Option 1 (OpenAI API key) OR Option 2 (Custom endpoint and model name) for AI capabilities to work. Do not mix the two options.
+
 Open your browser and navigate to `http://localhost:8080`.
+
+Example configuration for a local vLLM server:
+
+```bash
+VITE_OPENAI_API_ENDPOINT=http://localhost:8000/v1
+VITE_LLM_MODEL_NAME=Qwen/Qwen2.5-32B-Instruct-AWQ
+```
 
 ## Try it on our website
 
@@ -120,19 +165,22 @@ Open your browser and navigate to `http://localhost:8080`.
 
 ## 💚 Community & Support
 
--   [Discord](https://discord.gg/QeFwyWSKwC) (For live discussion with the community and the ChartDB team)
--   [GitHub Issues](https://github.com/chartdb/chartdb/issues) (For any bugs and errors you encounter using ChartDB)
--   [Twitter](https://x.com/chartdb_io) (Get news fast)
+- [Discord](https://discord.gg/QeFwyWSKwC) (For live discussion with the community and the ChartDB team)
+- [GitHub Issues](https://github.com/chartdb/chartdb/issues) (For any bugs and errors you encounter using ChartDB)
+- [Twitter](https://x.com/chartdb_io) (Get news fast)
 
 ## Contributing
 
 We welcome community contributions, big or small, and are here to guide you along
+
 the way. Message us in the [ChartDB Community Discord](https://discord.gg/QeFwyWSKwC).
 
 For more information on how to contribute, please see our
+
 [Contributing Guide](/CONTRIBUTING.md).
 
 This project is released with a [Contributor Code of Conduct](/CODE_OF_CONDUCT.md).
+
 By participating in this project, you agree to follow its terms.
 
 Thank you for helping us make ChartDB better for everyone :heart:.

--- a/default.conf.template
+++ b/default.conf.template
@@ -10,7 +10,11 @@ server {
 
     location /config.js {
         default_type application/javascript;
-        return 200 "window.env = { OPENAI_API_KEY: \"$OPENAI_API_KEY\" };";
+        return 200 "window.env = { 
+            OPENAI_API_KEY: \"$OPENAI_API_KEY\",
+            OPENAI_API_ENDPOINT: \"$OPENAI_API_ENDPOINT\",
+            LLM_MODEL_NAME: \"$LLM_MODEL_NAME\"
+        };";
     }
 
     error_page   500 502 503 504  /50x.html;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Replace placeholders in nginx.conf
-envsubst '${OPENAI_API_KEY}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+envsubst '${OPENAI_API_KEY} ${OPENAI_API_ENDPOINT} ${LLM_MODEL_NAME}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 
 # Start Nginx
 nginx -g "daemon off;"

--- a/src/lib/data/export-metadata/export-sql-script.ts
+++ b/src/lib/data/export-metadata/export-sql-script.ts
@@ -1,5 +1,5 @@
 import type { Diagram } from '../../domain/diagram';
-import { OPENAI_API_KEY } from '@/lib/env';
+import { OPENAI_API_KEY, OPENAI_API_ENDPOINT, LLM_MODEL_NAME } from '@/lib/env';
 import type { DatabaseType } from '@/lib/domain/database-type';
 import type { DBTable } from '@/lib/domain/db-table';
 import type { DataType } from '../data-types/data-types';
@@ -196,6 +196,26 @@ export const exportBaseSQL = (diagram: Diagram): string => {
     return sqlScript;
 };
 
+const validateConfiguration = () => {
+    const apiKey = window?.env?.OPENAI_API_KEY ?? OPENAI_API_KEY;
+    const baseUrl = window?.env?.OPENAI_API_ENDPOINT ?? OPENAI_API_ENDPOINT;
+    const modelName = window?.env?.LLM_MODEL_NAME ?? LLM_MODEL_NAME;
+
+    // If using custom endpoint and model, don't require OpenAI API key
+    if (baseUrl && modelName) {
+        return { useCustomEndpoint: true };
+    }
+
+    // If using OpenAI's service, require API key
+    if (apiKey) {
+        return { useCustomEndpoint: false };
+    }
+
+    throw new Error(
+        'Configuration Error: Either provide an OpenAI API key or both a custom endpoint and model name'
+    );
+};
+
 export const exportSQL = async (
     diagram: Diagram,
     databaseType: DatabaseType,
@@ -213,43 +233,72 @@ export const exportSQL = async (
         return cachedResult;
     }
 
+    // Validate configuration before proceeding
+    const { useCustomEndpoint } = validateConfiguration();
+
     const [{ streamText, generateText }, { createOpenAI }] = await Promise.all([
         import('ai'),
         import('@ai-sdk/openai'),
     ]);
 
-    const openai = createOpenAI({
-        apiKey: window?.env?.OPENAI_API_KEY ?? OPENAI_API_KEY,
-    });
+    const apiKey = window?.env?.OPENAI_API_KEY ?? OPENAI_API_KEY;
+    const baseUrl = window?.env?.OPENAI_API_ENDPOINT ?? OPENAI_API_ENDPOINT;
+    const modelName = window?.env?.LLM_MODEL_NAME ?? LLM_MODEL_NAME;
+
+    let config: { apiKey: string; baseUrl?: string };
+
+    if (useCustomEndpoint) {
+        config = {
+            apiKey: 'sk-xxx', // minimal valid API key format
+            baseUrl: baseUrl,
+        };
+    } else {
+        config = {
+            apiKey: apiKey,
+        };
+    }
+
+    const openai = createOpenAI(config);
 
     const prompt = generateSQLPrompt(databaseType, sqlScript);
 
-    if (options?.stream) {
-        const { textStream, text: textPromise } = await streamText({
-            model: openai('gpt-4o-mini-2024-07-18'),
+    try {
+        if (options?.stream) {
+            const { textStream, text: textPromise } = await streamText({
+                model: openai(modelName),
+                prompt: prompt,
+            });
+
+            for await (const textPart of textStream) {
+                if (options.signal?.aborted) {
+                    return '';
+                }
+                options.onResultStream(textPart);
+            }
+
+            const text = await textPromise;
+            setInCache(cacheKey, text);
+            return text;
+        }
+
+        const { text } = await generateText({
+            model: openai(modelName),
             prompt: prompt,
         });
 
-        for await (const textPart of textStream) {
-            if (options.signal?.aborted) {
-                return '';
-            }
-            options.onResultStream(textPart);
-        }
-
-        const text = await textPromise;
-
         setInCache(cacheKey, text);
         return text;
+    } catch (error: unknown) {
+        console.error('Error generating SQL:', error);
+        if (error instanceof Error && error.message.includes('API key')) {
+            throw new Error(
+                'Error: Please check your API configuration. If using a custom endpoint, make sure the endpoint URL is correct.'
+            );
+        }
+        throw new Error(
+            'Error generating SQL script. Please check your configuration and try again.'
+        );
     }
-
-    const { text } = await generateText({
-        model: openai('gpt-4o-mini-2024-07-18'),
-        prompt: prompt,
-    });
-
-    setInCache(cacheKey, text);
-    return text;
 };
 
 function getMySQLDataTypeSize(type: DataType) {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,4 +1,7 @@
 export const OPENAI_API_KEY: string = import.meta.env.VITE_OPENAI_API_KEY;
+export const OPENAI_API_ENDPOINT: string = import.meta.env
+    .VITE_OPENAI_API_ENDPOINT;
+export const LLM_MODEL_NAME: string = import.meta.env.VITE_LLM_MODEL_NAME;
 export const IS_CHARTDB_IO: boolean =
     import.meta.env.VITE_IS_CHARTDB_IO === 'true';
 export const APP_URL: string = import.meta.env.VITE_APP_URL;


### PR DESCRIPTION
# Add Support for Custom Inference Servers

## Description
This PR adds support for using custom OpenAI-compatible inference servers (like vLLM) as an alternative to the OpenAI API. This allows users to run ChartDB with their own inference servers and models.

## Changes
- Added support for custom API endpoints via `OPENAI_API_ENDPOINT` environment variable
- Added support for custom model names via `LLM_MODEL_NAME` environment variable
- Updated configuration to work with either OpenAI API key OR custom endpoint setup
- Updated documentation to reflect new configuration options
- Added proper error handling for custom endpoint configurations

## Testing
Tested with:
- vLLM server running Qwen/Qwen2.5-32B-Instruct-AWQ
- Verified SQL generation works with custom endpoint
- Verified build process with both OpenAI and custom endpoint configurations
- Tested Docker container builds and runs with new configuration options

## Related Issues
This enhancement allows users to run ChartDB with their own inference servers, reducing dependency on OpenAI's services.

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation has been updated
- [x] No new warnings introduced
- [x] Updated README.md with new configuration options

#