### PR TITLE
feat(image-export): add transparent and pattern export image toggles

### DIFF
--- a/src/context/export-image-context/export-image-context.tsx
+++ b/src/context/export-image-context/export-image-context.tsx
@@ -5,10 +5,11 @@ export type ImageType = 'png' | 'jpeg' | 'svg';
 export interface ExportImageContext {
     exportImage: (
         type: ImageType,
-        useBackground: boolean,
-        isTransparent: boolean,
-        hasWatermark: boolean,
-        scale: number
+        options: {
+            includePatternBG: boolean;
+            transparent: boolean;
+            scale: number;
+        }
     ) => Promise<void>;
 }
 

--- a/src/context/export-image-context/export-image-context.tsx
+++ b/src/context/export-image-context/export-image-context.tsx
@@ -3,7 +3,13 @@ import { emptyFn } from '@/lib/utils';
 
 export type ImageType = 'png' | 'jpeg' | 'svg';
 export interface ExportImageContext {
-    exportImage: (type: ImageType, scale: number) => Promise<void>;
+    exportImage: (
+        type: ImageType,
+        useBackground: boolean,
+        isTransparent: boolean,
+        hasWatermark: boolean,
+        scale: number
+    ) => Promise<void>;
 }
 
 export const exportImageContext = createContext<ExportImageContext>({

--- a/src/context/export-image-context/export-image-provider.tsx
+++ b/src/context/export-image-context/export-image-provider.tsx
@@ -135,30 +135,31 @@ export const ExportImageProvider: React.FC<React.PropsWithChildren> = ({
                 pattern.setAttribute('id', 'background-pattern');
                 pattern.setAttribute('width', String(16 * viewport.zoom));
                 pattern.setAttribute('height', String(16 * viewport.zoom));
+                pattern.setAttribute('patternUnits', 'userSpaceOnUse');
+                pattern.setAttribute(
+                    'patternTransform',
+                    `translate(${viewport.x % (16 * viewport.zoom)} ${viewport.y % (16 * viewport.zoom)})`
+                );
+
+                const dot = document.createElementNS(
+                    'http://www.w3.org/2000/svg',
+                    'circle'
+                );
+
+                const dotSize = viewport.zoom * 0.5;
+                dot.setAttribute('cx', String(viewport.zoom));
+                dot.setAttribute('cy', String(viewport.zoom));
+                dot.setAttribute('r', String(dotSize));
+                const dotColor =
+                    effectiveTheme === 'light' ? '#92939C' : '#777777';
+                dot.setAttribute('fill', dotColor);
+
                 if (useBackground) {
-                    pattern.setAttribute('patternUnits', 'userSpaceOnUse');
-                    pattern.setAttribute(
-                        'patternTransform',
-                        `translate(${viewport.x % (16 * viewport.zoom)} ${viewport.y % (16 * viewport.zoom)})`
-                    );
-
-                    const dot = document.createElementNS(
-                        'http://www.w3.org/2000/svg',
-                        'circle'
-                    );
-
-                    const dotSize = viewport.zoom * 0.5;
-                    dot.setAttribute('cx', String(viewport.zoom));
-                    dot.setAttribute('cy', String(viewport.zoom));
-                    dot.setAttribute('r', String(dotSize));
-                    const dotColor =
-                        effectiveTheme === 'light' ? '#92939C' : '#777777';
-                    dot.setAttribute('fill', dotColor);
-
                     pattern.appendChild(dot);
                     defs.appendChild(pattern);
-                    tempSvg.appendChild(defs);
                 }
+
+                tempSvg.appendChild(defs);
 
                 const backgroundRect = document.createElementNS(
                     'http://www.w3.org/2000/svg',

--- a/src/dialogs/export-image-dialog/export-image-dialog.tsx
+++ b/src/dialogs/export-image-dialog/export-image-dialog.tsx
@@ -17,14 +17,19 @@ import { useTranslation } from 'react-i18next';
 import type { ImageType } from '@/context/export-image-context/export-image-context';
 import { useExportImage } from '@/hooks/use-export-image';
 import { Checkbox } from '@/components/checkbox/checkbox';
+import {
+    Accordion,
+    AccordionContent,
+    AccordionItem,
+    AccordionTrigger,
+} from '@/components/accordion/accordion';
 
 export interface ExportImageDialogProps extends BaseDialogProps {
     format: ImageType;
 }
 
-const DEFAULT_HAS_PATTERN = true;
+const DEFAULT_INCLUDE_PATTERN_BG = true;
 const DEFAULT_TRANSPARENT = false;
-const DEFAULT_WATERMARK = true;
 const DEFAULT_SCALE = '2';
 export const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
     dialog,
@@ -32,31 +37,28 @@ export const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
 }) => {
     const { t } = useTranslation();
     const [scale, setScale] = useState<string>(DEFAULT_SCALE);
-    const [hasPattern, setHasPattern] = useState<boolean>(DEFAULT_HAS_PATTERN);
-    const [isTransparent, setIsTransparent] =
+    const [includePatternBG, setIncludePatternBG] = useState<boolean>(
+        DEFAULT_INCLUDE_PATTERN_BG
+    );
+    const [transparent, setTransparent] =
         useState<boolean>(DEFAULT_TRANSPARENT);
-    const [hasWatermark, setHasWatermark] =
-        useState<boolean>(DEFAULT_WATERMARK);
     const { exportImage } = useExportImage();
 
     useEffect(() => {
         if (!dialog.open) return;
         setScale(DEFAULT_SCALE);
-        setHasPattern(DEFAULT_HAS_PATTERN);
-        setIsTransparent(DEFAULT_TRANSPARENT);
-        setHasWatermark(DEFAULT_WATERMARK);
+        setIncludePatternBG(DEFAULT_INCLUDE_PATTERN_BG);
+        setTransparent(DEFAULT_TRANSPARENT);
     }, [dialog.open]);
     const { closeExportImageDialog } = useDialog();
 
     const handleExport = useCallback(() => {
-        exportImage(
-            format,
-            Boolean(hasPattern),
-            Boolean(isTransparent),
-            Boolean(hasWatermark),
-            Number(scale)
-        );
-    }, [exportImage, format, hasPattern, isTransparent, hasWatermark, scale]);
+        exportImage(format, {
+            transparent,
+            includePatternBG,
+            scale: Number(scale),
+        });
+    }, [exportImage, format, includePatternBG, transparent, scale]);
 
     const scaleOptions: SelectBoxOption[] = useMemo(
         () =>
@@ -84,68 +86,75 @@ export const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
                     </DialogDescription>
                 </DialogHeader>
                 <div className="flex flex-col gap-4 py-1">
-                    <div className="flex flex-col gap-2">
-                        <span className="font-semibold">
-                            {t('export_image_dialog.scale')}
-                        </span>
-                        <SelectBox
-                            options={scaleOptions}
-                            multiple={false}
-                            value={scale}
-                            onChange={(value) => setScale(value as string)}
-                        />
-                    </div>
-                    <div className="flex flex-col">
-                        <div className="flex items-center gap-2">
-                            <span className="font-semibold">
-                                {t('export_image_dialog.pattern')}
-                            </span>
-                            <Checkbox
-                                className="data-[state=checked]:border-pink-600 data-[state=checked]:bg-pink-600 data-[state=checked]:text-white"
-                                checked={hasPattern}
-                                onCheckedChange={(value) =>
-                                    setHasPattern(value as boolean)
-                                }
-                            />
-                        </div>
-                        <span className="text-sm text-muted-foreground">
-                            {t('export_image_dialog.pattern_description')}
-                        </span>
-                    </div>
-                    <div className="flex flex-col">
-                        <div className="flex items-center gap-2">
-                            <span className="font-semibold">
-                                {t('export_image_dialog.transparent')}
-                            </span>
-                            <Checkbox
-                                className="data-[state=checked]:border-pink-600 data-[state=checked]:bg-pink-600 data-[state=checked]:text-white"
-                                checked={isTransparent}
-                                onCheckedChange={(value) =>
-                                    setIsTransparent(value as boolean)
-                                }
-                            />
-                        </div>
-                        <span className="text-sm text-muted-foreground">
-                            {t('export_image_dialog.transparent_description')}
-                        </span>
-                    </div>
-                    <div className="flex flex-col">
-                        <div className="flex items-center gap-2">
-                            <span className="font-semibold">
-                                {t('export_image_dialog.watermark')}
-                            </span>
-                            <Checkbox
-                                className="data-[state=checked]:border-pink-600 data-[state=checked]:bg-pink-600 data-[state=checked]:text-white"
-                                checked={hasWatermark}
-                                onCheckedChange={(value) =>
-                                    setHasWatermark(value as boolean)
-                                }
-                            />
-                        </div>
-                        <span className="text-sm text-muted-foreground">
-                            {t('export_image_dialog.watermark_description')}
-                        </span>
-                    </div>
+                    <SelectBox
+                        options={scaleOptions}
+                        multiple={false}
+                        value={scale}
+                        onChange={(value) => setScale(value as string)}
+                    />
+                    <Accordion type="single" collapsible className="w-full">
+                        <AccordionItem value="settings">
+                            <AccordionTrigger className="justify-start py-1.5">
+                                {t('export_image_dialog.advanced_options')}
+                            </AccordionTrigger>
+                            <AccordionContent>
+                                <div className="flex flex-col gap-3 py-2">
+                                    <div className="flex items-start gap-3">
+                                        <Checkbox
+                                            id="pattern-checkbox"
+                                            className="mt-1 data-[state=checked]:border-pink-600 data-[state=checked]:bg-pink-600 data-[state=checked]:text-white"
+                                            checked={includePatternBG}
+                                            onCheckedChange={(value) =>
+                                                setIncludePatternBG(
+                                                    value as boolean
+                                                )
+                                            }
+                                        />
+                                        <div className="flex flex-col">
+                                            <label
+                                                htmlFor="pattern-checkbox"
+                                                className="cursor-pointer font-medium"
+                                            >
+                                                {t(
+                                                    'export_image_dialog.pattern'
+                                                )}
+                                            </label>
+                                            <span className="text-sm text-muted-foreground">
+                                                {t(
+                                                    'export_image_dialog.pattern_description'
+                                                )}
+                                            </span>
+                                        </div>
+                                    </div>
+                                    <div className="flex items-start gap-3">
+                                        <Checkbox
+                                            id="transparent-checkbox"
+                                            className="mt-1 data-[state=checked]:border-pink-600 data-[state=checked]:bg-pink-600 data-[state=checked]:text-white"
+                                            checked={transparent}
+                                            onCheckedChange={(value) =>
+                                                setTransparent(value as boolean)
+                                            }
+                                        />
+                                        <div className="flex flex-col">
+                                            <label
+                                                htmlFor="transparent-checkbox"
+                                                className="cursor-pointer font-medium"
+                                            >
+                                                {t(
+                                                    'export_image_dialog.transparent'
+                                                )}
+                                            </label>
+                                            <span className="text-sm text-muted-foreground">
+                                                {t(
+                                                    'export_image_dialog.transparent_description'
+                                                )}
+                                            </span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </AccordionContent>
+                        </AccordionItem>
+                    </Accordion>
                 </div>
                 <DialogFooter className="flex gap-1 md:justify-between">
                     <DialogClose asChild>

--- a/src/dialogs/export-image-dialog/export-image-dialog.tsx
+++ b/src/dialogs/export-image-dialog/export-image-dialog.tsx
@@ -16,11 +16,15 @@ import type { BaseDialogProps } from '../common/base-dialog-props';
 import { useTranslation } from 'react-i18next';
 import type { ImageType } from '@/context/export-image-context/export-image-context';
 import { useExportImage } from '@/hooks/use-export-image';
+import { Checkbox } from '@/components/checkbox/checkbox';
 
 export interface ExportImageDialogProps extends BaseDialogProps {
     format: ImageType;
 }
 
+const DEFAULT_HAS_PATTERN = true;
+const DEFAULT_TRANSPARENT = false;
+const DEFAULT_WATERMARK = true;
 const DEFAULT_SCALE = '2';
 export const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
     dialog,
@@ -28,17 +32,31 @@ export const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
 }) => {
     const { t } = useTranslation();
     const [scale, setScale] = useState<string>(DEFAULT_SCALE);
+    const [hasPattern, setHasPattern] = useState<boolean>(DEFAULT_HAS_PATTERN);
+    const [isTransparent, setIsTransparent] =
+        useState<boolean>(DEFAULT_TRANSPARENT);
+    const [hasWatermark, setHasWatermark] =
+        useState<boolean>(DEFAULT_WATERMARK);
     const { exportImage } = useExportImage();
 
     useEffect(() => {
         if (!dialog.open) return;
         setScale(DEFAULT_SCALE);
+        setHasPattern(DEFAULT_HAS_PATTERN);
+        setIsTransparent(DEFAULT_TRANSPARENT);
+        setHasWatermark(DEFAULT_WATERMARK);
     }, [dialog.open]);
     const { closeExportImageDialog } = useDialog();
 
     const handleExport = useCallback(() => {
-        exportImage(format, Number(scale));
-    }, [exportImage, format, scale]);
+        exportImage(
+            format,
+            Boolean(hasPattern),
+            Boolean(isTransparent),
+            Boolean(hasWatermark),
+            Number(scale)
+        );
+    }, [exportImage, format, hasPattern, isTransparent, hasWatermark, scale]);
 
     const scaleOptions: SelectBoxOption[] = useMemo(
         () =>
@@ -65,14 +83,68 @@ export const ExportImageDialog: React.FC<ExportImageDialogProps> = ({
                         {t('export_image_dialog.description')}
                     </DialogDescription>
                 </DialogHeader>
-                <div className="grid gap-4 py-1">
-                    <div className="grid w-full items-center gap-4">
+                <div className="flex flex-col gap-4 py-1">
+                    <div className="flex flex-col gap-2">
+                        <span className="font-semibold">
+                            {t('export_image_dialog.scale')}
+                        </span>
                         <SelectBox
                             options={scaleOptions}
                             multiple={false}
                             value={scale}
                             onChange={(value) => setScale(value as string)}
                         />
+                    </div>
+                    <div className="flex flex-col">
+                        <div className="flex items-center gap-2">
+                            <span className="font-semibold">
+                                {t('export_image_dialog.pattern')}
+                            </span>
+                            <Checkbox
+                                className="data-[state=checked]:border-pink-600 data-[state=checked]:bg-pink-600 data-[state=checked]:text-white"
+                                checked={hasPattern}
+                                onCheckedChange={(value) =>
+                                    setHasPattern(value as boolean)
+                                }
+                            />
+                        </div>
+                        <span className="text-sm text-muted-foreground">
+                            {t('export_image_dialog.pattern_description')}
+                        </span>
+                    </div>
+                    <div className="flex flex-col">
+                        <div className="flex items-center gap-2">
+                            <span className="font-semibold">
+                                {t('export_image_dialog.transparent')}
+                            </span>
+                            <Checkbox
+                                className="data-[state=checked]:border-pink-600 data-[state=checked]:bg-pink-600 data-[state=checked]:text-white"
+                                checked={isTransparent}
+                                onCheckedChange={(value) =>
+                                    setIsTransparent(value as boolean)
+                                }
+                            />
+                        </div>
+                        <span className="text-sm text-muted-foreground">
+                            {t('export_image_dialog.transparent_description')}
+                        </span>
+                    </div>
+                    <div className="flex flex-col">
+                        <div className="flex items-center gap-2">
+                            <span className="font-semibold">
+                                {t('export_image_dialog.watermark')}
+                            </span>
+                            <Checkbox
+                                className="data-[state=checked]:border-pink-600 data-[state=checked]:bg-pink-600 data-[state=checked]:text-white"
+                                checked={hasWatermark}
+                                onCheckedChange={(value) =>
+                                    setHasWatermark(value as boolean)
+                                }
+                            />
+                        </div>
+                        <span className="text-sm text-muted-foreground">
+                            {t('export_image_dialog.watermark_description')}
+                        </span>
                     </div>
                 </div>
                 <DialogFooter className="flex gap-1 md:justify-between">

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -351,6 +351,12 @@ export const ar: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'إلغاء',
             export: 'تصدير',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/bn.ts
+++ b/src/i18n/locales/bn.ts
@@ -352,6 +352,12 @@ export const bn: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'বাতিল করুন',
             export: 'রপ্তানি করুন',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -355,6 +355,12 @@ export const de: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'Abbrechen',
             export: 'Exportieren',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -339,20 +339,18 @@ export const en = {
 
         export_image_dialog: {
             title: 'Export Image',
-            description: 'Adjust export settings for your image.',
+            description: 'Choose the scale factor for export:',
             scale_1x: '1x Regular',
             scale_2x: '2x (Recommended)',
             scale_3x: '3x',
             scale_4x: '4x',
             cancel: 'Cancel',
             export: 'Export',
-            scale: 'Image scale:',
-            pattern: 'Background pattern:',
-            pattern_description: 'Whether the background pattern is visible.',
-            transparent: 'Transparent background:',
-            transparent_description: 'Whether the background is transparent.',
-            watermark: 'Watermark:',
-            watermark_description: 'Whether the watermark is visible.',
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -339,13 +339,20 @@ export const en = {
 
         export_image_dialog: {
             title: 'Export Image',
-            description: 'Choose the scale factor for export:',
+            description: 'Adjust export settings for your image.',
             scale_1x: '1x Regular',
             scale_2x: '2x (Recommended)',
             scale_3x: '3x',
             scale_4x: '4x',
             cancel: 'Cancel',
             export: 'Export',
+            scale: 'Image scale:',
+            pattern: 'Background pattern:',
+            pattern_description: 'Whether the background pattern is visible.',
+            transparent: 'Transparent background:',
+            transparent_description: 'Whether the background is transparent.',
+            watermark: 'Watermark:',
+            watermark_description: 'Whether the watermark is visible.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -344,6 +344,12 @@ export const es: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'Cancelar',
             export: 'Exportar',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -307,6 +307,12 @@ export const fr: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'Annuler',
             export: 'Exporter',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         multiple_schemas_alert: {

--- a/src/i18n/locales/gu.ts
+++ b/src/i18n/locales/gu.ts
@@ -352,6 +352,12 @@ export const gu: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'રદ કરો',
             export: 'નિકાસ કરો',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/hi.ts
+++ b/src/i18n/locales/hi.ts
@@ -355,6 +355,12 @@ export const hi: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'रद्द करें',
             export: 'निर्यात करें',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/id_ID.ts
+++ b/src/i18n/locales/id_ID.ts
@@ -350,6 +350,12 @@ export const id_ID: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'Batal',
             export: 'Ekspor',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -359,6 +359,12 @@ export const ja: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'キャンセル',
             export: 'エクスポート',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/ko_KR.ts
+++ b/src/i18n/locales/ko_KR.ts
@@ -350,6 +350,12 @@ export const ko_KR: LanguageTranslation = {
             scale_4x: '4x',
             cancel: '취소',
             export: '내보내기',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/mr.ts
+++ b/src/i18n/locales/mr.ts
@@ -358,6 +358,12 @@ export const mr: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'रद्द करा',
             export: 'निर्यात करा',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/ne.ts
+++ b/src/i18n/locales/ne.ts
@@ -355,6 +355,12 @@ export const ne: LanguageTranslation = {
             scale_4x: '४x',
             cancel: 'रद्द गर्नुहोस्',
             export: 'निर्यात गर्नुहोस्',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/pt_BR.ts
+++ b/src/i18n/locales/pt_BR.ts
@@ -353,6 +353,12 @@ export const pt_BR: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'Cancelar',
             export: 'Exportar',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -350,6 +350,12 @@ export const ru: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'Отменить',
             export: 'Экспортировать',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/te.ts
+++ b/src/i18n/locales/te.ts
@@ -354,6 +354,12 @@ export const te: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'రద్దు',
             export: 'ఎగుమతి',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -346,6 +346,12 @@ export const tr: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'İptal',
             export: 'Dışa Aktar',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
         new_table_schema_dialog: {
             title: 'Şema Seç',

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -351,6 +351,12 @@ export const uk: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'Скасувати',
             export: 'Експортувати',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -350,6 +350,12 @@ export const vi: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'Hủy',
             export: 'Xuất',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/zh_CN.ts
+++ b/src/i18n/locales/zh_CN.ts
@@ -347,6 +347,12 @@ export const zh_CN: LanguageTranslation = {
             scale_4x: '4x',
             cancel: '取消',
             export: '导出',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/i18n/locales/zh_TW.ts
+++ b/src/i18n/locales/zh_TW.ts
@@ -346,6 +346,12 @@ export const zh_TW: LanguageTranslation = {
             scale_4x: '4x',
             cancel: '取消',
             export: '匯出',
+            // TODO: Translate
+            advanced_options: 'Advanced Options',
+            pattern: 'Include background pattern',
+            pattern_description: 'Add subtle grid pattern to background.',
+            transparent: 'Transparent background',
+            transparent_description: 'Remove background color from image.',
         },
 
         new_table_schema_dialog: {

--- a/src/pages/editor-page/top-navbar/menu/menu.tsx
+++ b/src/pages/editor-page/top-navbar/menu/menu.tsx
@@ -80,7 +80,11 @@ export const Menu: React.FC<MenuProps> = () => {
     };
 
     const exportSVG = useCallback(() => {
-        exportImage('svg', 1);
+        exportImage('svg', {
+            scale: 1,
+            transparent: true,
+            includePatternBG: false,
+        });
     }, [exportImage]);
 
     const exportPNG = useCallback(() => {


### PR DESCRIPTION
This PR adds additional image export settings:
pattern - toggles the background dot pattern
transparent - background transparency
watermark - presence of watermark

I am sorry, I created the localization only for en.
![image](https://github.com/user-attachments/assets/f1e3fc94-4efc-4f84-b9f4-86a733274a59)
