### PR TITLE
Added Show/Hide Toolbar Functionality

### DIFF
--- a/src/context/local-config-context/local-config-context.tsx
+++ b/src/context/local-config-context/local-config-context.tsx
@@ -35,6 +35,9 @@ export interface LocalConfigContext {
 
     showMiniMapOnCanvas: boolean;
     setShowMiniMapOnCanvas: (showMiniMapOnCanvas: boolean) => void;
+
+    showRelationships: boolean;
+    setShowRelationships: (showRelationships: boolean) => void;
 }
 
 export const LocalConfigContext = createContext<LocalConfigContext>({
@@ -64,4 +67,7 @@ export const LocalConfigContext = createContext<LocalConfigContext>({
 
     showMiniMapOnCanvas: false,
     setShowMiniMapOnCanvas: emptyFn,
+
+    showRelationships: false,
+    setShowRelationships: () => {}
 });

--- a/src/context/local-config-context/local-config-provider.tsx
+++ b/src/context/local-config-context/local-config-provider.tsx
@@ -12,6 +12,7 @@ const githubRepoOpenedKey = 'github_repo_opened';
 const starUsDialogLastOpenKey = 'star_us_dialog_last_open';
 const showDependenciesOnCanvasKey = 'show_dependencies_on_canvas';
 const showMiniMapOnCanvasKey = 'show_minimap_on_canvas';
+const showRelationshipsKey = 'show_relationships';
 
 export const LocalConfigProvider: React.FC<React.PropsWithChildren> = ({
     children,
@@ -58,6 +59,11 @@ export const LocalConfigProvider: React.FC<React.PropsWithChildren> = ({
     const [showMiniMapOnCanvas, setShowMiniMapOnCanvas] =
         React.useState<boolean>(
             (localStorage.getItem(showMiniMapOnCanvasKey) || 'true') === 'true'
+        );
+
+        const [showRelationships, setShowRelationships] =
+        React.useState<boolean>(
+            (localStorage.getItem(showRelationshipsKey) || 'true') === 'true'
         );
 
     useEffect(() => {
@@ -108,6 +114,12 @@ export const LocalConfigProvider: React.FC<React.PropsWithChildren> = ({
         );
     }, [showMiniMapOnCanvas]);
 
+    useEffect(() => {
+        localStorage.setItem(
+            showRelationshipsKey,
+            showRelationships.toString()
+        );
+    }, [showRelationships]);
     return (
         <LocalConfigContext.Provider
             value={{
@@ -129,6 +141,9 @@ export const LocalConfigProvider: React.FC<React.PropsWithChildren> = ({
                 setShowDependenciesOnCanvas,
                 showMiniMapOnCanvas,
                 setShowMiniMapOnCanvas,
+                showRelationships,
+                setShowRelationships,
+
             }}
         >
             {children}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -22,6 +22,8 @@ export const en = {
             },
             view: {
                 view: 'View',
+                show_relationships: 'Show Relationships',
+                hide_relationships: 'Hide Relationships',
                 show_sidebar: 'Show Sidebar',
                 hide_sidebar: 'Hide Sidebar',
                 hide_cardinality: 'Hide Cardinality',

--- a/src/pages/editor-page/canvas/relationship-edge/relationship-edge.tsx
+++ b/src/pages/editor-page/canvas/relationship-edge/relationship-edge.tsx
@@ -171,9 +171,11 @@ export const RelationshipEdge: React.FC<EdgeProps<RelationshipEdgeType>> = ({
                 : false,
         [checkIfRelationshipRemoved, relationship?.id]
     );
+
     if (!showRelationships) {
         return null;
     }
+    
     return (
         <>
             <path

--- a/src/pages/editor-page/canvas/relationship-edge/relationship-edge.tsx
+++ b/src/pages/editor-page/canvas/relationship-edge/relationship-edge.tsx
@@ -8,6 +8,7 @@ import { useLayout } from '@/hooks/use-layout';
 import { cn } from '@/lib/utils';
 import { getCardinalityMarkerId } from '../canvas-utils';
 import { useDiff } from '@/context/diff-context/use-diff';
+import { useLocalConfig } from '@/hooks/use-local-config';
 
 export type RelationshipEdgeType = Edge<
     {
@@ -41,6 +42,7 @@ export const RelationshipEdge: React.FC<EdgeProps<RelationshipEdgeType>> = ({
         openRelationshipFromSidebar(id);
     }, [id, openRelationshipFromSidebar, selectSidebarSection]);
 
+    const { showRelationships } = useLocalConfig();
     const edgeNumber = useMemo(
         () =>
             relationships
@@ -169,7 +171,9 @@ export const RelationshipEdge: React.FC<EdgeProps<RelationshipEdgeType>> = ({
                 : false,
         [checkIfRelationshipRemoved, relationship?.id]
     );
-
+    if (!showRelationships) {
+        return null;
+    }
     return (
         <>
             <path

--- a/src/pages/editor-page/top-navbar/menu/menu.tsx
+++ b/src/pages/editor-page/top-navbar/menu/menu.tsx
@@ -192,9 +192,7 @@ export const Menu: React.FC<MenuProps> = () => {
     }, [showRelationships, setShowRelationships]);
 
     const emojiAI = '✨';
-    console.log(typeof setShowRelationships);
-    console.log(setShowRelationships);
-    console.log("LocalConfig Output:", useLocalConfig);
+
     return (
         <Menubar className="h-8 border-none py-2 shadow-none md:h-10 md:py-0">
             <MenubarMenu>

--- a/src/pages/editor-page/top-navbar/menu/menu.tsx
+++ b/src/pages/editor-page/top-navbar/menu/menu.tsx
@@ -62,6 +62,8 @@ export const Menu: React.FC<MenuProps> = () => {
         showDependenciesOnCanvas,
         setShowMiniMapOnCanvas,
         showMiniMapOnCanvas,
+        setShowRelationships,
+        showRelationships,
     } = useLocalConfig();
     const { t } = useTranslation();
     const { redo, undo, hasRedo, hasUndo } = useHistory();
@@ -185,8 +187,14 @@ export const Menu: React.FC<MenuProps> = () => {
         setShowMiniMapOnCanvas(!showMiniMapOnCanvas);
     }, [showMiniMapOnCanvas, setShowMiniMapOnCanvas]);
 
-    const emojiAI = '✨';
+    const showOrHideRelationships = useCallback(() => {
+        setShowRelationships(!showRelationships);
+    }, [showRelationships, setShowRelationships]);
 
+    const emojiAI = '✨';
+    console.log(typeof setShowRelationships);
+    console.log(setShowRelationships);
+    console.log("LocalConfig Output:", useLocalConfig);
     return (
         <Menubar className="h-8 border-none py-2 shadow-none md:h-10 md:py-0">
             <MenubarMenu>
@@ -433,6 +441,12 @@ export const Menu: React.FC<MenuProps> = () => {
                         </MenubarShortcut>
                     </MenubarItem>
                     <MenubarSeparator />
+                    <MenubarItem onClick={showOrHideRelationships}>
+                        {showRelationships
+                            ? t('menu.view.hide_relationships')
+                            : t('menu.view.show_relationships')}
+                    </MenubarItem>
+
                     <MenubarItem onClick={showOrHideCardinality}>
                         {showCardinality
                             ? t('menu.view.hide_cardinality')


### PR DESCRIPTION
Fixes #497

Fixes #497

### Description
This pull request adds the **"Show/Hide Relationship Links"** option in the Relationship Menu, allowing users to toggle relationship visibility.

### Changes Included
- Implemented show/hide functionality for relationship links.
- Updated UI logic in the Relationship Menu.
- Ensured state persistence for relationship visibility.

### Testing Notes
- Verified relationship links toggle correctly.
- No unexpected UI issues observed.