### PR TITLE
fix(expanded-table): persist expanded state across renders

### DIFF
--- a/src/lib/domain/db-table.ts
+++ b/src/lib/domain/db-table.ts
@@ -41,6 +41,7 @@ export interface DBTable {
     width?: number;
     comments?: string;
     order?: number;
+    expanded?: boolean;
 }
 
 export const dbTableSchema: z.ZodType<DBTable> = z.object({
@@ -58,6 +59,7 @@ export const dbTableSchema: z.ZodType<DBTable> = z.object({
     width: z.number().optional(),
     comments: z.string().optional(),
     order: z.number().optional(),
+    expanded: z.boolean().optional(),
 });
 
 export const shouldShowTablesBySchemaFilter = (

--- a/src/lib/domain/db-table.ts
+++ b/src/lib/domain/db-table.ts
@@ -26,6 +26,15 @@ import { DatabaseType } from './database-type';
 import type { DatabaseMetadata } from '../data/import-metadata/metadata-types/database-metadata';
 import { z } from 'zod';
 
+// Add this constant to match the one in table-node.tsx
+export const TABLE_MINIMIZED_FIELDS = 10;
+// Field height in pixels (each field is approximately 2rem/32px)
+export const FIELD_HEIGHT = 32;
+// Height of table header & footer in pixels
+export const TABLE_HEADER_HEIGHT = 90;
+// Height of the "show more" button
+export const TABLE_FOOTER_HEIGHT = 32;
+
 export interface DBTable {
     id: string;
     name: string;
@@ -177,8 +186,8 @@ export const adjustTablePositions = ({
     const relationships = deepCopy(inputRelationships);
 
     const adjustPositionsForTables = (tablesToAdjust: DBTable[]) => {
-        const tableWidth = 200;
-        const tableHeight = 300;
+        const defaultTableWidth = 200;
+        const defaultTableHeight = 300;
         const gapX = 100;
         const gapY = 100;
         const startX = 100;
@@ -207,6 +216,35 @@ export const adjustTablePositions = ({
         const positionedTables = new Set<string>();
         const tablePositions = new Map<string, { x: number; y: number }>();
 
+        const getTableWidth = (tableId: string): number => {
+            const table = tablesToAdjust.find((t) => t.id === tableId);
+            return table?.width ?? defaultTableWidth;
+        };
+
+        const getTableHeight = (tableId: string): number => {
+            const table = tablesToAdjust.find((t) => t.id === tableId);
+            if (!table) return defaultTableHeight;
+
+            // Calculate how many fields are visible
+            const fieldCount = table.fields.length;
+            let visibleFieldCount = fieldCount;
+
+            // If not expanded, use minimum of field count and TABLE_MINIMIZED_FIELDS
+            if (!table.expanded) {
+                visibleFieldCount = Math.min(
+                    fieldCount,
+                    TABLE_MINIMIZED_FIELDS
+                );
+            }
+
+            // Calculate height based on visible fields
+            const fieldsHeight = visibleFieldCount * FIELD_HEIGHT;
+            const showMoreButtonHeight =
+                fieldCount > TABLE_MINIMIZED_FIELDS ? TABLE_FOOTER_HEIGHT : 0;
+
+            return TABLE_HEADER_HEIGHT + fieldsHeight + showMoreButtonHeight;
+        };
+
         const isOverlapping = (
             x: number,
             y: number,
@@ -215,8 +253,8 @@ export const adjustTablePositions = ({
             for (const [tableId, pos] of tablePositions) {
                 if (tableId === currentTableId) continue;
                 if (
-                    Math.abs(x - pos.x) < tableWidth + gapX &&
-                    Math.abs(y - pos.y) < tableHeight + gapY
+                    Math.abs(x - pos.x) < getTableWidth(tableId) + gapX &&
+                    Math.abs(y - pos.y) < getTableHeight(tableId) + gapY
                 ) {
                     return true;
                 }
@@ -229,7 +267,8 @@ export const adjustTablePositions = ({
             baseY: number,
             tableId: string
         ): { x: number; y: number } => {
-            const spiralStep = Math.max(tableWidth, tableHeight) / 2;
+            const spiralStep =
+                Math.max(getTableWidth(tableId), getTableHeight(tableId)) / 2;
             let angle = 0;
             let radius = 0;
             let iterations = 0;
@@ -281,10 +320,21 @@ export const adjustTablePositions = ({
                         (t) => t.id === connectedTableId
                     );
                     if (connectedTable) {
+                        const tableWidth = getTableWidth(table.id);
+                        const connectedTableWidth =
+                            getTableWidth(connectedTableId);
+                        const avgWidth = (tableWidth + connectedTableWidth) / 2;
+
+                        const tableHeight = getTableHeight(table.id);
+                        const connectedTableHeight =
+                            getTableHeight(connectedTableId);
+                        const avgHeight =
+                            (tableHeight + connectedTableHeight) / 2;
+
                         const newX =
-                            x + Math.cos(angle) * (tableWidth + gapX * 2);
+                            x + Math.cos(angle) * (avgWidth + gapX * 2);
                         const newY =
-                            y + Math.sin(angle) * (tableHeight + gapY * 2);
+                            y + Math.sin(angle) * (avgHeight + gapY * 2);
                         positionTable(connectedTable, newX, newY);
                         angle += angleStep;
                     }
@@ -297,6 +347,8 @@ export const adjustTablePositions = ({
             if (!positionedTables.has(table.id)) {
                 const row = Math.floor(index / 6);
                 const col = index % 6;
+                const tableWidth = getTableWidth(table.id);
+                const tableHeight = getTableHeight(table.id);
                 const x = startX + col * (tableWidth + gapX * 2);
                 const y = startY + row * (tableHeight + gapY * 2);
                 positionTable(table, x, y);

--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -760,7 +760,10 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables }) => {
 
                 const measured = {
                     ...(node.measured ?? {}),
-                    height: calcTableHeight(event.data.fields.length),
+                    height: calcTableHeight({
+                        ...node.data.table,
+                        fields: event.data.fields,
+                    }),
                 };
 
                 newOverlappingGraph = findTableOverlapping(

--- a/src/pages/editor-page/canvas/table-node/table-node.tsx
+++ b/src/pages/editor-page/canvas/table-node/table-node.tsx
@@ -60,7 +60,7 @@ export const TableNode: React.FC<NodeProps<TableNodeType>> = React.memo(
         const { updateTable, relationships, readonly } = useChartDB();
         const edges = useStore((store) => store.edges) as EdgeType[];
         const { openTableFromSidebar, selectSidebarSection } = useLayout();
-        const [expanded, setExpanded] = useState(false);
+        const [expanded, setExpanded] = useState(table.expanded ?? false);
         const { t } = useTranslation();
         const [editMode, setEditMode] = useState(false);
         const [tableName, setTableName] = useState(table.name);
@@ -139,7 +139,9 @@ export const TableNode: React.FC<NodeProps<TableNodeType>> = React.memo(
         }, [table.id, updateTable]);
 
         const toggleExpand = () => {
-            setExpanded(!expanded);
+            const newExpandedState = !expanded;
+            setExpanded(newExpandedState);
+            updateTable(table.id, { expanded: newExpandedState });
         };
 
         const isMustDisplayedField = useCallback(

--- a/src/pages/editor-page/canvas/table-node/table-node.tsx
+++ b/src/pages/editor-page/canvas/table-node/table-node.tsx
@@ -138,11 +138,13 @@ export const TableNode: React.FC<NodeProps<TableNodeType>> = React.memo(
             });
         }, [table.id, updateTable]);
 
-        const toggleExpand = () => {
-            const newExpandedState = !expanded;
-            setExpanded(newExpandedState);
-            updateTable(table.id, { expanded: newExpandedState });
-        };
+        const toggleExpand = useCallback(() => {
+            setExpanded((prev) => {
+                const value = !prev;
+                updateTable(table.id, { expanded: value });
+                return value;
+            });
+        }, [table.id, updateTable]);
 
         const isMustDisplayedField = useCallback(
             (field: DBField) => {


### PR DESCRIPTION
1. Store is expanded
![image](https://github.com/user-attachments/assets/8b71dc63-5314-403c-817a-1ef3f14115d8)
2. Reorder based on tables size


https://github.com/user-attachments/assets/67711113-b20f-48e6-928d-fdfc7186fd74


