### PR TITLE
feat: add right-click context menu with edit/delete options for areas…

### DIFF
--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -486,6 +486,11 @@ export const ar: LanguageTranslation = {
             add_relationship: 'Add Relationship', // TODO: Translate
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'تعديل اسم المنطقة',
+            delete_area: 'حذف المنطقة',
+        },
+
         snap_to_grid_tooltip: '({{key}} مغنظة الشبكة (اضغط مع الاستمرار على',
 
         tool_tips: {

--- a/src/i18n/locales/bn.ts
+++ b/src/i18n/locales/bn.ts
@@ -491,6 +491,11 @@ export const bn: LanguageTranslation = {
             add_relationship: 'Add Relationship', // TODO: Translate
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'এলাকার নাম সম্পাদনা করুন',
+            delete_area: 'এলাকা মুছে ফেলুন',
+        },
+
         snap_to_grid_tooltip: 'গ্রিডে স্ন্যাপ করুন (অবস্থান {{key}})',
 
         tool_tips: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -495,6 +495,11 @@ export const de: LanguageTranslation = {
             add_relationship: 'Add Relationship', // TODO: Translate
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'Bereichsname bearbeiten',
+            delete_area: 'Bereich löschen',
+        },
+
         // TODO: Add translations
         snap_to_grid_tooltip: 'Snap to Grid (Hold {{key}})',
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -479,6 +479,11 @@ export const en = {
             add_relationship: 'Add Relationship',
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'Edit Area Name',
+            delete_area: 'Delete Area',
+        },
+
         snap_to_grid_tooltip: 'Snap to Grid (Hold {{key}})',
 
         tool_tips: {

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -492,6 +492,11 @@ export const es: LanguageTranslation = {
             add_relationship: 'Add Relationship', // TODO: Translate
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'Editar Nombre del Área',
+            delete_area: 'Eliminar Área',
+        },
+
         // TODO: Add translations
         snap_to_grid_tooltip: 'Snap to Grid (Hold {{key}})',
 

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -489,6 +489,11 @@ export const fr: LanguageTranslation = {
             add_relationship: 'Ajouter une Relation',
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'Modifier le Nom de la Zone',
+            delete_area: 'Supprimer la Zone',
+        },
+
         snap_to_grid_tooltip:
             'Aligner sur la grille (maintenir la touche {{key}})',
 

--- a/src/i18n/locales/gu.ts
+++ b/src/i18n/locales/gu.ts
@@ -492,6 +492,11 @@ export const gu: LanguageTranslation = {
             add_relationship: 'Add Relationship', // TODO: Translate
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'વિસ્તાર નામ સંપાદિત કરો',
+            delete_area: 'વિસ્તાર કાઢી નાખો',
+        },
+
         snap_to_grid_tooltip: 'ગ્રિડ પર સ્નેપ કરો (જમાવટ {{key}})',
 
         tool_tips: {

--- a/src/i18n/locales/hi.ts
+++ b/src/i18n/locales/hi.ts
@@ -495,6 +495,11 @@ export const hi: LanguageTranslation = {
             add_relationship: 'Add Relationship', // TODO: Translate
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'क्षेत्र का नाम संपादित करें',
+            delete_area: 'क्षेत्र हटाएँ',
+        },
+
         // TODO: Add translations
         snap_to_grid_tooltip: 'Snap to Grid (Hold {{key}})',
 

--- a/src/i18n/locales/hr.ts
+++ b/src/i18n/locales/hr.ts
@@ -484,6 +484,11 @@ export const hr: LanguageTranslation = {
             add_relationship: 'Dodaj vezu',
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'Uredi naziv područja',
+            delete_area: 'Izbriši područje',
+        },
+
         snap_to_grid_tooltip: 'Priljepljivanje na mrežu (Drži {{key}})',
 
         tool_tips: {

--- a/src/i18n/locales/id_ID.ts
+++ b/src/i18n/locales/id_ID.ts
@@ -491,6 +491,11 @@ export const id_ID: LanguageTranslation = {
             add_relationship: 'Add Relationship', // TODO: Translate
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'Ubah Nama Area',
+            delete_area: 'Hapus Area',
+        },
+
         snap_to_grid_tooltip: 'Snap ke Kisi (Tahan {{key}})',
 
         tool_tips: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -497,6 +497,11 @@ export const ja: LanguageTranslation = {
             add_relationship: 'Add Relationship', // TODO: Translate
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'エリア名を編集',
+            delete_area: 'エリアを削除',
+        },
+
         // TODO: Add translations
         snap_to_grid_tooltip: 'Snap to Grid (Hold {{key}})',
 

--- a/src/i18n/locales/ko_KR.ts
+++ b/src/i18n/locales/ko_KR.ts
@@ -488,6 +488,11 @@ export const ko_KR: LanguageTranslation = {
             add_relationship: 'Add Relationship', // TODO: Translate
         },
 
+        area_node_context_menu: {
+            edit_area_name: '영역 이름 편집',
+            delete_area: '영역 삭제',
+        },
+
         snap_to_grid_tooltip: '그리드에 맞추기 ({{key}}를 누른채 유지)',
 
         tool_tips: {

--- a/src/i18n/locales/mr.ts
+++ b/src/i18n/locales/mr.ts
@@ -501,6 +501,11 @@ export const mr: LanguageTranslation = {
             add_relationship: 'Add Relationship', // TODO: Translate
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'क्षेत्राचे नाव संपादित करा',
+            delete_area: 'क्षेत्र हटवा',
+        },
+
         // TODO: Add translations
         snap_to_grid_tooltip: 'Snap to Grid (Hold {{key}})',
 

--- a/src/i18n/locales/ne.ts
+++ b/src/i18n/locales/ne.ts
@@ -495,6 +495,11 @@ export const ne: LanguageTranslation = {
             add_relationship: 'Add Relationship', // TODO: Translate
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'क्षेत्रको नाम सम्पादन गर्नुहोस्',
+            delete_area: 'क्षेत्र हटाउनुहोस्',
+        },
+
         snap_to_grid_tooltip: 'ग्रिडमा स्न्याप गर्नुहोस् ({{key}} थिच्नुहोस)',
 
         tool_tips: {

--- a/src/i18n/locales/pt_BR.ts
+++ b/src/i18n/locales/pt_BR.ts
@@ -493,6 +493,11 @@ export const pt_BR: LanguageTranslation = {
             add_relationship: 'Add Relationship', // TODO: Translate
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'Editar Nome da Área',
+            delete_area: 'Excluir Área',
+        },
+
         // TODO: Add translations
         snap_to_grid_tooltip: 'Snap to Grid (Hold {{key}})',
 

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -488,6 +488,11 @@ export const ru: LanguageTranslation = {
             add_relationship: 'Добавить связь',
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'Изменить название области',
+            delete_area: 'Удалить область',
+        },
+
         copy_to_clipboard: 'Скопировать в буфер обмена',
         copied: 'Скопировано!',
         snap_to_grid_tooltip: 'Выравнивание по сетке (Удерживайте {{key}})',

--- a/src/i18n/locales/te.ts
+++ b/src/i18n/locales/te.ts
@@ -497,6 +497,11 @@ export const te: LanguageTranslation = {
             add_relationship: 'Add Relationship', // TODO: Translate
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'ప్రాంత పేరును సవరించు',
+            delete_area: 'ప్రాంతాన్ని తొలగించు',
+        },
+
         // TODO: Translate
         snap_to_grid_tooltip: 'Snap to Grid (Hold {{key}})',
 

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -481,6 +481,11 @@ export const tr: LanguageTranslation = {
             add_relationship: 'Add Relationship', // TODO: Translate
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'Alan Adını Düzenle',
+            delete_area: 'Alanı Sil',
+        },
+
         // TODO: Translate
         snap_to_grid_tooltip: 'Snap to Grid (Hold {{key}})',
 

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -488,6 +488,11 @@ export const uk: LanguageTranslation = {
             add_relationship: 'Add Relationship', // TODO: Translate
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'Редагувати назву області',
+            delete_area: 'Видалити область',
+        },
+
         snap_to_grid_tooltip: 'Вирівнювати за сіткою (Отримуйте {{key}})',
 
         tool_tips: {

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -489,6 +489,11 @@ export const vi: LanguageTranslation = {
             add_relationship: 'Add Relationship', // TODO: Translate
         },
 
+        area_node_context_menu: {
+            edit_area_name: 'Chỉnh sửa tên khu vực',
+            delete_area: 'Xóa khu vực',
+        },
+
         snap_to_grid_tooltip: 'Căn lưới (Giữ phím {{key}})',
 
         tool_tips: {

--- a/src/i18n/locales/zh_CN.ts
+++ b/src/i18n/locales/zh_CN.ts
@@ -484,6 +484,11 @@ export const zh_CN: LanguageTranslation = {
             add_relationship: 'Add Relationship', // TODO: Translate
         },
 
+        area_node_context_menu: {
+            edit_area_name: '编辑区域名称',
+            delete_area: '删除区域',
+        },
+
         snap_to_grid_tooltip: '对齐到网格（按住 {{key}}）',
 
         tool_tips: {

--- a/src/i18n/locales/zh_TW.ts
+++ b/src/i18n/locales/zh_TW.ts
@@ -484,6 +484,11 @@ export const zh_TW: LanguageTranslation = {
             add_relationship: 'Add Relationship', // TODO: Translate
         },
 
+        area_node_context_menu: {
+            edit_area_name: '編輯區域名稱',
+            delete_area: '刪除區域',
+        },
+
         snap_to_grid_tooltip: '對齊網格（按住 {{key}}）',
 
         tool_tips: {

--- a/src/pages/editor-page/canvas/area-node/area-node-context-menu.tsx
+++ b/src/pages/editor-page/canvas/area-node/area-node-context-menu.tsx
@@ -1,0 +1,58 @@
+import {
+    ContextMenu,
+    ContextMenuContent,
+    ContextMenuItem,
+    ContextMenuTrigger,
+} from '@/components/context-menu/context-menu';
+import { useBreakpoint } from '@/hooks/use-breakpoint';
+import { useChartDB } from '@/hooks/use-chartdb';
+import type { Area } from '@/lib/domain/area';
+import { Pencil, Trash2 } from 'lucide-react';
+import React, { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export interface AreaNodeContextMenuProps {
+    area: Area;
+    onEditName?: () => void;
+}
+
+export const AreaNodeContextMenu: React.FC<
+    React.PropsWithChildren<AreaNodeContextMenuProps>
+> = ({ children, area, onEditName }) => {
+    const { removeArea, readonly } = useChartDB();
+    const { t } = useTranslation();
+    const { isMd: isDesktop } = useBreakpoint('md');
+
+    const removeAreaHandler = useCallback(() => {
+        removeArea(area.id);
+    }, [removeArea, area.id]);
+
+    if (!isDesktop || readonly) {
+        return <>{children}</>;
+    }
+    return (
+        <ContextMenu>
+            <ContextMenuTrigger>{children}</ContextMenuTrigger>
+            <ContextMenuContent>
+                {onEditName && (
+                    <ContextMenuItem
+                        onClick={onEditName}
+                        className="flex justify-between gap-3"
+                    >
+                        <span>
+                            {t('area_node_context_menu.edit_area_name')}
+                        </span>
+                        <Pencil className="size-3.5" />
+                    </ContextMenuItem>
+                )}
+                <ContextMenuItem
+                    onClick={removeAreaHandler}
+                    className="flex justify-between gap-3"
+                >
+                    <span>{t('area_node_context_menu.delete_area')}</span>
+                    <Trash2 className="size-3.5 text-red-700" />
+                </ContextMenuItem>
+            </ContextMenuContent>
+        </ContextMenu>
+    );
+};

--- a/src/pages/editor-page/canvas/area-node/area-node.tsx
+++ b/src/pages/editor-page/canvas/area-node/area-node.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import type { NodeProps, Node } from '@xyflow/react';
 import { NodeResizer } from '@xyflow/react';
 import type { Area } from '@/lib/domain/area';
@@ -12,9 +12,10 @@ import {
 } from '@/components/tooltip/tooltip';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
-import { Check, GripVertical } from 'lucide-react';
+import { Check, GripVertical, Pencil } from 'lucide-react';
 import { Button } from '@/components/button/button';
 import { useLayout } from '@/hooks/use-layout';
+import { AreaNodeContextMenu } from './area-node-context-menu';
 
 export type AreaNodeType = Node<
     {
@@ -56,83 +57,120 @@ export const AreaNode: React.FC<NodeProps<AreaNodeType>> = React.memo(
         useKeyPressEvent('Enter', editAreaName);
         useKeyPressEvent('Escape', abortEdit);
 
-        const enterEditMode = (e: React.MouseEvent) => {
-            e.stopPropagation();
-            setEditMode(true);
-        };
+        const enterEditMode = useCallback(
+            (e?: React.MouseEvent) => {
+                e?.stopPropagation();
+                setAreaName(area.name); // Reset to current name
+                setEditMode(true);
+            },
+            [area.name]
+        );
+
+        useEffect(() => {
+            if (editMode) {
+                // Small delay to ensure the input is rendered
+                const timeoutId = setTimeout(() => {
+                    if (inputRef.current) {
+                        inputRef.current.focus();
+                        inputRef.current.select();
+                    }
+                }, 50); // Slightly longer delay to ensure DOM is ready
+
+                return () => clearTimeout(timeoutId);
+            }
+        }, [editMode]);
 
         return (
-            <div
-                className={cn(
-                    'flex h-full flex-col rounded-md border-2 shadow-sm',
-                    selected ? 'border-pink-600' : 'border-transparent'
-                )}
-                style={{
-                    backgroundColor: `${area.color}15`,
-                    borderColor: selected ? undefined : area.color,
-                }}
-                onClick={(e) => {
-                    if (e.detail === 2) {
-                        openAreaInEditor();
-                    }
-                }}
-            >
-                <NodeResizer
-                    isVisible={focused}
-                    lineClassName="!border-4 !border-transparent"
-                    handleClassName="!h-[18px] !w-[18px] !rounded-full !bg-pink-600"
-                    minHeight={100}
-                    minWidth={100}
-                />
-                <div className="group flex h-8 items-center justify-between rounded-t-md px-2">
-                    <div className="flex w-full items-center gap-1">
-                        <GripVertical className="size-4 shrink-0 text-slate-700 opacity-60 dark:text-slate-300" />
+            <AreaNodeContextMenu area={area} onEditName={enterEditMode}>
+                <div
+                    className={cn(
+                        'flex h-full flex-col rounded-md border-2 shadow-sm',
+                        selected ? 'border-pink-600' : 'border-transparent'
+                    )}
+                    style={{
+                        backgroundColor: `${area.color}15`,
+                        borderColor: selected ? undefined : area.color,
+                    }}
+                    onClick={(e) => {
+                        if (e.detail === 2) {
+                            openAreaInEditor();
+                        }
+                    }}
+                >
+                    <NodeResizer
+                        isVisible={focused}
+                        lineClassName="!border-4 !border-transparent"
+                        handleClassName="!h-[18px] !w-[18px] !rounded-full !bg-pink-600"
+                        minHeight={100}
+                        minWidth={100}
+                    />
+                    <div className="group flex h-8 items-center justify-between rounded-t-md px-2">
+                        <div className="flex w-full items-center gap-1">
+                            <GripVertical className="size-4 shrink-0 text-slate-700 opacity-60 dark:text-slate-300" />
 
-                        {editMode && !readonly ? (
-                            <div className="flex w-full items-center">
-                                <Input
-                                    ref={inputRef}
-                                    autoFocus
-                                    type="text"
-                                    placeholder={area.name}
-                                    value={areaName}
-                                    onClick={(e) => e.stopPropagation()}
-                                    onChange={(e) =>
-                                        setAreaName(e.target.value)
-                                    }
-                                    className="h-6 bg-white/70 focus-visible:ring-0 dark:bg-slate-900/70"
-                                />
-                                <Button
-                                    variant="ghost"
-                                    className="ml-1 size-6 p-0 hover:bg-white/20"
-                                    onClick={editAreaName}
-                                >
-                                    <Check className="size-3.5 text-slate-700 dark:text-slate-300" />
-                                </Button>
-                            </div>
-                        ) : !readonly ? (
-                            <Tooltip>
-                                <TooltipTrigger asChild>
-                                    <div
-                                        className="text-editable max-w-[200px] cursor-text truncate px-1 py-0.5 text-base font-semibold text-slate-700 dark:text-slate-300"
-                                        onDoubleClick={enterEditMode}
+                            {editMode && !readonly ? (
+                                <div className="flex items-center">
+                                    <Input
+                                        ref={inputRef}
+                                        autoFocus
+                                        type="text"
+                                        placeholder={area.name}
+                                        value={areaName}
+                                        onClick={(e) => e.stopPropagation()}
+                                        onChange={(e) =>
+                                            setAreaName(e.target.value)
+                                        }
+                                        className="h-6 bg-white/70 focus-visible:ring-0 dark:bg-slate-900/70"
+                                        style={{
+                                            width: `${Math.max(
+                                                areaName.length * 8 + 20,
+                                                80
+                                            )}px`,
+                                        }}
+                                    />
+                                    <Button
+                                        variant="ghost"
+                                        className="ml-1 size-6 p-0 hover:bg-white/20"
+                                        onClick={editAreaName}
                                     >
-                                        {area.name}
-                                    </div>
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                    {t('tool_tips.double_click_to_edit')}
-                                </TooltipContent>
-                            </Tooltip>
-                        ) : (
-                            <div className="truncate px-1 py-0.5 text-base font-semibold text-slate-700 dark:text-slate-300">
-                                {area.name}
-                            </div>
-                        )}
+                                        <Check className="size-3.5 text-slate-700 dark:text-slate-300" />
+                                    </Button>
+                                </div>
+                            ) : !readonly ? (
+                                <div className="flex items-center">
+                                    <Tooltip>
+                                        <TooltipTrigger asChild>
+                                            <div
+                                                className="text-editable cursor-text px-1 py-0.5 text-base font-semibold text-slate-700 dark:text-slate-300"
+                                                onDoubleClick={enterEditMode}
+                                            >
+                                                {area.name}
+                                            </div>
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                            {t(
+                                                'tool_tips.double_click_to_edit'
+                                            )}
+                                        </TooltipContent>
+                                    </Tooltip>
+                                    <Button
+                                        variant="ghost"
+                                        className="ml-1 size-5 p-0 opacity-0 transition-opacity hover:bg-white/20 group-hover:opacity-100"
+                                        onClick={enterEditMode}
+                                    >
+                                        <Pencil className="size-3 text-slate-700 dark:text-slate-300" />
+                                    </Button>
+                                </div>
+                            ) : (
+                                <div className="truncate px-1 py-0.5 text-base font-semibold text-slate-700 dark:text-slate-300">
+                                    {area.name}
+                                </div>
+                            )}
+                        </div>
                     </div>
+                    <div className="flex-1" />
                 </div>
-                <div className="flex-1" />
-            </div>
+            </AreaNodeContextMenu>
         );
     }
 );

--- a/src/pages/editor-page/canvas/table-node/table-node.tsx
+++ b/src/pages/editor-page/canvas/table-node/table-node.tsx
@@ -19,6 +19,7 @@ import {
     SquareDot,
     SquarePlus,
     SquareMinus,
+    Pencil,
 } from 'lucide-react';
 import { Label } from '@/components/label/label';
 import {
@@ -282,16 +283,34 @@ export const TableNode: React.FC<NodeProps<TableNodeType>> = React.memo(
         useKeyPressEvent('Enter', editTableName);
         useKeyPressEvent('Escape', abortEdit);
 
-        const enterEditMode = useCallback((e: React.MouseEvent) => {
-            e.stopPropagation();
-            setEditMode(true);
-        }, []);
+        const enterEditMode = useCallback(
+            (e: React.MouseEvent) => {
+                e.stopPropagation();
+                setTableName(table.name); // Reset to current name
+                setEditMode(true);
+            },
+            [table.name]
+        );
 
         React.useEffect(() => {
             if (table.name.trim()) {
                 setTableName(table.name.trim());
             }
         }, [table.name]);
+
+        useEffect(() => {
+            if (editMode) {
+                // Small delay to ensure the input is rendered
+                const timeoutId = setTimeout(() => {
+                    if (inputRef.current) {
+                        inputRef.current.focus();
+                        inputRef.current.select();
+                    }
+                }, 50); // Slightly longer delay to ensure DOM is ready
+
+                return () => clearTimeout(timeoutId);
+            }
+        }, [editMode]);
 
         const tableClassName = useMemo(
             () =>
@@ -461,19 +480,30 @@ export const TableNode: React.FC<NodeProps<TableNodeType>> = React.memo(
                                     </Button>
                                 </>
                             ) : (
-                                <Tooltip>
-                                    <TooltipTrigger asChild>
-                                        <Label
-                                            className="text-editable truncate px-2 py-0.5 text-sm font-bold"
-                                            onDoubleClick={enterEditMode}
-                                        >
-                                            {table.name}
-                                        </Label>
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                        {t('tool_tips.double_click_to_edit')}
-                                    </TooltipContent>
-                                </Tooltip>
+                                <div className="flex min-w-0 items-center">
+                                    <Tooltip>
+                                        <TooltipTrigger asChild>
+                                            <Label
+                                                className="text-editable truncate px-2 py-0.5 text-sm font-bold"
+                                                onDoubleClick={enterEditMode}
+                                            >
+                                                {table.name}
+                                            </Label>
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                            {t(
+                                                'tool_tips.double_click_to_edit'
+                                            )}
+                                        </TooltipContent>
+                                    </Tooltip>
+                                    <Button
+                                        variant="ghost"
+                                        className="ml-1 size-5 shrink-0 p-0 opacity-0 transition-opacity hover:bg-primary-foreground group-hover:opacity-100"
+                                        onClick={enterEditMode}
+                                    >
+                                        <Pencil className="size-3 text-slate-500 dark:text-slate-400" />
+                                    </Button>
+                                </div>
                             )}
                         </div>
                         <div className="hidden shrink-0 flex-row group-hover:flex">

--- a/src/pages/editor-page/top-navbar/diagram-name.tsx
+++ b/src/pages/editor-page/top-navbar/diagram-name.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Button } from '@/components/button/button';
-import { Check } from 'lucide-react';
+import { Check, Pencil } from 'lucide-react';
 import { Input } from '@/components/input/input';
 import { useChartDB } from '@/hooks/use-chartdb';
 import { useClickAway, useKeyPressEvent } from 'react-use';
@@ -42,12 +42,28 @@ export const DiagramName: React.FC<DiagramNameProps> = () => {
     useClickAway(inputRef, editDiagramName);
     useKeyPressEvent('Enter', editDiagramName);
 
-    const enterEditMode = (
-        event: React.MouseEvent<HTMLHeadingElement, MouseEvent>
-    ) => {
-        event.stopPropagation();
-        setEditMode(true);
-    };
+    useEffect(() => {
+        if (editMode) {
+            // Small delay to ensure the input is rendered
+            const timeoutId = setTimeout(() => {
+                if (inputRef.current) {
+                    inputRef.current.focus();
+                    inputRef.current.select();
+                }
+            }, 50); // Slightly longer delay to ensure DOM is ready
+
+            return () => clearTimeout(timeoutId);
+        }
+    }, [editMode]);
+
+    const enterEditMode = useCallback(
+        (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
+            event.stopPropagation();
+            setEditedDiagramName(diagramName);
+            setEditMode(true);
+        },
+        [diagramName]
+    );
 
     return (
         <div className="group">
@@ -69,7 +85,7 @@ export const DiagramName: React.FC<DiagramNameProps> = () => {
                 />
                 <div className="flex flex-row items-center gap-1">
                     {editMode ? (
-                        <>
+                        <div className="flex items-center">
                             <Input
                                 ref={inputRef}
                                 autoFocus
@@ -81,15 +97,21 @@ export const DiagramName: React.FC<DiagramNameProps> = () => {
                                     setEditedDiagramName(e.target.value)
                                 }
                                 className="ml-1 h-7 focus-visible:ring-0"
+                                style={{
+                                    width: `${Math.max(
+                                        editedDiagramName.length * 8 + 20,
+                                        100
+                                    )}px`,
+                                }}
                             />
                             <Button
                                 variant="ghost"
-                                className="flex size-7 p-2 text-slate-500 hover:bg-primary-foreground hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-300"
+                                className="ml-1 flex size-7 p-2 text-slate-500 hover:bg-primary-foreground hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-300"
                                 onClick={editDiagramName}
                             >
                                 <Check />
                             </Button>
-                        </>
+                        </div>
                     ) : (
                         <>
                             <Tooltip>
@@ -110,6 +132,13 @@ export const DiagramName: React.FC<DiagramNameProps> = () => {
                                     {t('tool_tips.double_click_to_edit')}
                                 </TooltipContent>
                             </Tooltip>
+                            <Button
+                                variant="ghost"
+                                className="ml-1 size-5 p-0 opacity-0 transition-opacity hover:bg-primary-foreground group-hover:opacity-100"
+                                onClick={enterEditMode}
+                            >
+                                <Pencil className="size-3 text-slate-500 dark:text-slate-400" />
+                            </Button>
                         </>
                     )}
                 </div>


### PR DESCRIPTION
  **What's New:**
  - Area Context Menu: Right-click areas to edit name or delete
  - Pencil Icons: Hover to reveal edit buttons for areas, tables, and diagram name
  - Better Edit Mode: Auto-focus, text selection, and dynamic input width
  - Translations: Added support for 20+ languages

  **Key Changes:**
  - New AreaNodeContextMenu component with edit/delete options
  - Enhanced edit UX across areas, tables, and diagram name
  - Consistent behavior: double-click, pencil click, or context menu to edit
  
<img width="1150" height="680" alt="image" src="https://github.com/user-attachments/assets/847c6442-bc5c-4e84-b86f-1199cd606233" />