### PR TITLE
feat(postgres): add support hash index types

### DIFF
--- a/src/context/chartdb-context/chartdb-context.tsx
+++ b/src/context/chartdb-context/chartdb-context.tsx
@@ -153,7 +153,7 @@ export interface ChartDBContext {
     ) => Promise<void>;
 
     // Index operations
-    createIndex: (tableId: string) => Promise<DBIndex>;
+    createIndex: (tableId: string, type?: DBIndex['type']) => Promise<DBIndex>;
     addIndex: (
         tableId: string,
         index: DBIndex,

--- a/src/context/chartdb-context/chartdb-context.tsx
+++ b/src/context/chartdb-context/chartdb-context.tsx
@@ -153,7 +153,7 @@ export interface ChartDBContext {
     ) => Promise<void>;
 
     // Index operations
-    createIndex: (tableId: string, type?: DBIndex['type']) => Promise<DBIndex>;
+    createIndex: (tableId: string) => Promise<DBIndex>;
     addIndex: (
         tableId: string,
         index: DBIndex,

--- a/src/context/chartdb-context/chartdb-provider.tsx
+++ b/src/context/chartdb-context/chartdb-provider.tsx
@@ -950,7 +950,7 @@ export const ChartDBProvider: React.FC<
     );
 
     const createIndex: ChartDBContext['createIndex'] = useCallback(
-        async (tableId: string) => {
+        async (tableId: string, type?: DBIndex['type']) => {
             const table = getTable(tableId);
             const index: DBIndex = {
                 id: generateId(),
@@ -958,6 +958,7 @@ export const ChartDBProvider: React.FC<
                 fieldIds: [],
                 unique: false,
                 createdAt: Date.now(),
+                ...(type && { type }),
             };
 
             await addIndex(tableId, index);

--- a/src/context/chartdb-context/chartdb-provider.tsx
+++ b/src/context/chartdb-context/chartdb-provider.tsx
@@ -950,7 +950,7 @@ export const ChartDBProvider: React.FC<
     );
 
     const createIndex: ChartDBContext['createIndex'] = useCallback(
-        async (tableId: string, type?: DBIndex['type']) => {
+        async (tableId: string) => {
             const table = getTable(tableId);
             const index: DBIndex = {
                 id: generateId(),
@@ -958,7 +958,6 @@ export const ChartDBProvider: React.FC<
                 fieldIds: [],
                 unique: false,
                 createdAt: Date.now(),
-                ...(type && { type }),
             };
 
             await addIndex(tableId, index);

--- a/src/context/diagram-filter-context/diagram-filter-provider.tsx
+++ b/src/context/diagram-filter-context/diagram-filter-provider.tsx
@@ -18,7 +18,7 @@ import {
 import { useStorage } from '@/hooks/use-storage';
 import { useChartDB } from '@/hooks/use-chartdb';
 import { filterTable } from '@/lib/domain/diagram-filter/filter';
-import { schemaNameToSchemaId } from '@/lib/domain';
+import { databasesWithSchemas, schemaNameToSchemaId } from '@/lib/domain';
 import { defaultSchemas } from '@/lib/data/default-schemas';
 import type { ChartDBEvent } from '../chartdb-context/chartdb-context';
 
@@ -246,7 +246,7 @@ export const DiagramFilterProvider: React.FC<React.PropsWithChildren> = ({
     const toggleTableFilter: DiagramFilterContext['toggleTableFilter'] =
         useCallback(
             (tableId: string) => {
-                if (!defaultSchemas[databaseType]) {
+                if (!databasesWithSchemas.includes(databaseType)) {
                     // No schemas, toggle table filter without schema context
                     toggleTableFilterForNoSchema(tableId);
                     return;

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -149,6 +149,7 @@ export const ar: LanguageTranslation = {
                         title: 'خصائص الفهرس',
                         name: 'الإسم',
                         unique: 'فريد',
+                        index_type: 'نوع الفهرس',
                         delete_index: 'حذف الفهرس',
                     },
                     table_actions: {

--- a/src/i18n/locales/bn.ts
+++ b/src/i18n/locales/bn.ts
@@ -151,6 +151,7 @@ export const bn: LanguageTranslation = {
                         title: 'ইনডেক্স কর্ম',
                         name: 'নাম',
                         unique: 'অদ্বিতীয়',
+                        index_type: 'ইনডেক্স ধরন',
                         delete_index: 'ইনডেক্স মুছুন',
                     },
                     table_actions: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -152,6 +152,7 @@ export const de: LanguageTranslation = {
                         title: 'Indexattribute',
                         name: 'Name',
                         unique: 'Eindeutig',
+                        index_type: 'Indextyp',
                         delete_index: 'Index löschen',
                     },
                     table_actions: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -145,6 +145,7 @@ export const en = {
                         title: 'Index Attributes',
                         name: 'Name',
                         unique: 'Unique',
+                        index_type: 'Index Type',
                         delete_index: 'Delete Index',
                     },
                     table_actions: {

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -150,6 +150,7 @@ export const es: LanguageTranslation = {
                         title: 'Atributos del Índice',
                         name: 'Nombre',
                         unique: 'Único',
+                        index_type: 'Tipo de Índice',
                         delete_index: 'Eliminar Índice',
                     },
                     table_actions: {

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -148,6 +148,7 @@ export const fr: LanguageTranslation = {
                         title: "Attributs de l'Index",
                         name: 'Nom',
                         unique: 'Unique',
+                        index_type: "Type d'index",
                         delete_index: "Supprimer l'Index",
                     },
                     table_actions: {

--- a/src/i18n/locales/gu.ts
+++ b/src/i18n/locales/gu.ts
@@ -152,6 +152,7 @@ export const gu: LanguageTranslation = {
                         title: 'ઇન્ડેક્સ લક્ષણો',
                         name: 'નામ',
                         unique: 'અદ્વિતીય',
+                        index_type: 'ઇન્ડેક્સ પ્રકાર',
                         delete_index: 'ઇન્ડેક્સ કાઢી નાખો',
                     },
                     table_actions: {

--- a/src/i18n/locales/hi.ts
+++ b/src/i18n/locales/hi.ts
@@ -151,6 +151,7 @@ export const hi: LanguageTranslation = {
                         title: 'सूचकांक विशेषताएँ',
                         name: 'नाम',
                         unique: 'अद्वितीय',
+                        index_type: 'इंडेक्स प्रकार',
                         delete_index: 'सूचकांक हटाएँ',
                     },
                     table_actions: {

--- a/src/i18n/locales/hr.ts
+++ b/src/i18n/locales/hr.ts
@@ -146,6 +146,7 @@ export const hr: LanguageTranslation = {
                         title: 'Atributi indeksa',
                         name: 'Naziv',
                         unique: 'Jedinstven',
+                        index_type: 'Vrsta indeksa',
                         delete_index: 'Izbriši indeks',
                     },
                     table_actions: {

--- a/src/i18n/locales/id_ID.ts
+++ b/src/i18n/locales/id_ID.ts
@@ -150,6 +150,7 @@ export const id_ID: LanguageTranslation = {
                         title: 'Atribut Indeks',
                         name: 'Nama',
                         unique: 'Unik',
+                        index_type: 'Tipe Indeks',
                         delete_index: 'Hapus Indeks',
                     },
                     table_actions: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -154,6 +154,7 @@ export const ja: LanguageTranslation = {
                         title: 'インデックス属性',
                         name: '名前',
                         unique: 'ユニーク',
+                        index_type: 'インデックスタイプ',
                         delete_index: 'インデックスを削除',
                     },
                     table_actions: {

--- a/src/i18n/locales/ko_KR.ts
+++ b/src/i18n/locales/ko_KR.ts
@@ -150,6 +150,7 @@ export const ko_KR: LanguageTranslation = {
                         title: '인덱스 속성',
                         name: '인덱스 명',
                         unique: '유니크 여부',
+                        index_type: '인덱스 타입',
                         delete_index: '인덱스 삭제',
                     },
                     table_actions: {

--- a/src/i18n/locales/mr.ts
+++ b/src/i18n/locales/mr.ts
@@ -153,6 +153,7 @@ export const mr: LanguageTranslation = {
                         title: 'इंडेक्स गुणधर्म',
                         name: 'नाव',
                         unique: 'युनिक',
+                        index_type: 'इंडेक्स प्रकार',
                         delete_index: 'इंडेक्स हटवा',
                     },
                     table_actions: {

--- a/src/i18n/locales/ne.ts
+++ b/src/i18n/locales/ne.ts
@@ -151,6 +151,7 @@ export const ne: LanguageTranslation = {
                         title: 'सूचक विशेषताहरू',
                         name: 'नाम',
                         unique: 'अनन्य',
+                        index_type: 'इन्डेक्स प्रकार',
                         delete_index: 'सूचक हटाउनुहोस्',
                     },
                     table_actions: {

--- a/src/i18n/locales/pt_BR.ts
+++ b/src/i18n/locales/pt_BR.ts
@@ -151,6 +151,7 @@ export const pt_BR: LanguageTranslation = {
                         title: 'Atributos do Índice',
                         name: 'Nome',
                         unique: 'Único',
+                        index_type: 'Tipo de Índice',
                         delete_index: 'Excluir Índice',
                     },
                     table_actions: {

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -147,6 +147,7 @@ export const ru: LanguageTranslation = {
                         title: 'Атрибуты индекса',
                         name: 'Имя',
                         unique: 'Уникальный',
+                        index_type: 'Тип индекса',
                         delete_index: 'Удалить индекс',
                     },
                     table_actions: {

--- a/src/i18n/locales/te.ts
+++ b/src/i18n/locales/te.ts
@@ -151,6 +151,7 @@ export const te: LanguageTranslation = {
                         title: 'ఇండెక్స్ గుణాలు',
                         name: 'పేరు',
                         unique: 'అద్వితీయ',
+                        index_type: 'ఇండెక్స్ రకం',
                         delete_index: 'ఇండెక్స్ తొలగించు',
                     },
                     table_actions: {

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -150,6 +150,7 @@ export const tr: LanguageTranslation = {
                         title: 'İndeks Özellikleri',
                         name: 'Ad',
                         unique: 'Tekil',
+                        index_type: 'İndeks Türü',
                         delete_index: 'İndeksi Sil',
                     },
                     table_actions: {

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -149,6 +149,7 @@ export const uk: LanguageTranslation = {
                         title: 'Атрибути індексу',
                         name: 'Назва індекса',
                         unique: 'Унікальний',
+                        index_type: 'Тип індексу',
                         delete_index: 'Видалити індекс',
                     },
                     table_actions: {

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -150,6 +150,7 @@ export const vi: LanguageTranslation = {
                         title: 'Thuộc tính chỉ mục',
                         name: 'Tên',
                         unique: 'Giá trị duy nhất',
+                        index_type: 'Loại chỉ mục',
                         delete_index: 'Xóa chỉ mục',
                     },
                     table_actions: {

--- a/src/i18n/locales/zh_CN.ts
+++ b/src/i18n/locales/zh_CN.ts
@@ -147,6 +147,7 @@ export const zh_CN: LanguageTranslation = {
                         title: '索引属性',
                         name: '名称',
                         unique: '唯一',
+                        index_type: '索引类型',
                         delete_index: '删除索引',
                     },
                     table_actions: {

--- a/src/i18n/locales/zh_TW.ts
+++ b/src/i18n/locales/zh_TW.ts
@@ -147,6 +147,7 @@ export const zh_TW: LanguageTranslation = {
                         title: '索引屬性',
                         name: '名稱',
                         unique: '唯一',
+                        index_type: '索引類型',
                         delete_index: '刪除索引',
                     },
                     table_actions: {

--- a/src/lib/data/export-metadata/export-per-type/postgresql.ts
+++ b/src/lib/data/export-metadata/export-per-type/postgresql.ts
@@ -405,7 +405,7 @@ export function exportPostgreSQL({
                                     .filter(Boolean);
 
                                 return indexFieldNames.length > 0
-                                    ? `CREATE ${index.unique ? 'UNIQUE ' : ''}INDEX ${indexName} ON ${tableName} (${indexFieldNames.join(', ')});`
+                                    ? `CREATE ${index.unique ? 'UNIQUE ' : ''}INDEX ${indexName} ON ${tableName}${index.type && index.type !== 'btree' ? ` USING ${index.type.toUpperCase()}` : ''} (${indexFieldNames.join(', ')});`
                                     : '';
                             })
                             .filter(Boolean);

--- a/src/lib/domain/db-index.ts
+++ b/src/lib/domain/db-index.ts
@@ -9,6 +9,7 @@ export interface DBIndex {
     unique: boolean;
     fieldIds: string[];
     createdAt: number;
+    type?: 'btree' | 'hash' | 'gist' | 'gin' | 'spgist' | 'brin';
 }
 
 export const dbIndexSchema: z.ZodType<DBIndex> = z.object({
@@ -17,6 +18,7 @@ export const dbIndexSchema: z.ZodType<DBIndex> = z.object({
     unique: z.boolean(),
     fieldIds: z.array(z.string()),
     createdAt: z.number(),
+    type: z.enum(['btree', 'hash', 'gist', 'gin', 'spgist', 'brin']).optional(),
 });
 
 export const createIndexesFromMetadata = ({
@@ -36,5 +38,6 @@ export const createIndexesFromMetadata = ({
                 .map((c) => fields.find((f) => f.name === c.name)?.id)
                 .filter((id): id is string => id !== undefined),
             createdAt: Date.now(),
+            type: idx.index_type?.toLowerCase() as DBIndex['type'],
         })
     );

--- a/src/pages/editor-page/canvas/canvas-filter/canvas-filter.tsx
+++ b/src/pages/editor-page/canvas/canvas-filter/canvas-filter.tsx
@@ -16,7 +16,6 @@ import type { TreeNode } from '@/components/tree-view/tree';
 import { ScrollArea } from '@/components/scroll-area/scroll-area';
 import { useDiagramFilter } from '@/context/diagram-filter-context/use-diagram-filter';
 import { ToggleGroup, ToggleGroupItem } from '@/components/toggle/toggle-group';
-import { defaultSchemas } from '@/lib/data/default-schemas';
 import type {
     GroupingMode,
     NodeContext,
@@ -26,6 +25,7 @@ import type {
 } from './types';
 import { generateTreeDataByAreas, generateTreeDataBySchemas } from './utils';
 import { FilterItemActions } from './filter-item-actions';
+import { databasesWithSchemas } from '@/lib/domain';
 
 export interface CanvasFilterProps {
     onClose: () => void;
@@ -63,7 +63,7 @@ export const CanvasFilter: React.FC<CanvasFilterProps> = ({ onClose }) => {
     );
 
     const databaseWithSchemas = useMemo(
-        () => !!defaultSchemas[databaseType],
+        () => databasesWithSchemas.includes(databaseType),
         [databaseType]
     );
 

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-content/table-index/table-index.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-content/table-index/table-index.tsx
@@ -66,10 +66,8 @@ export const TableIndex: React.FC<TableIndexProps> = ({
 
     const indexTypeOptions = useMemo(
         () =>
-            allIndexTypeOptions.filter(
-                (option) =>
-                    !databaseIndexTypes[databaseType] ||
-                    databaseIndexTypes[databaseType]?.includes(option.value)
+            allIndexTypeOptions.filter((option) =>
+                databaseIndexTypes[databaseType]?.includes(option.value)
             ),
         [databaseType]
     );


### PR DESCRIPTION
  1. PostgreSQL Hash Index Support:
    - Added index type property to the DBIndex model
    - Extended UI to show index type dropdown for PostgreSQL databases
    - Implemented proper SQL export with USING HASH clause
  2. Single Field Constraint for Hash Indexes:
    - When hash index type is selected, only one field can be selected
    - If user tries to select another field, it replaces the current selection
    - When switching from B-tree to Hash with multiple fields selected, it automatically keeps only the first field
    - The UI shows "(single column only)" label for Hash index type
   
<img width="1050" height="1044" alt="image" src="https://github.com/user-attachments/assets/d60a4fcb-b537-4574-b112-93d9996ec64e" />