### PR TITLE
fix: update relationship lines when table width changes via expand/sh…

### DIFF
--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -294,6 +294,7 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables }) => {
         setEdges,
         showDependenciesOnCanvas,
         databaseType,
+        tables, // Add tables to force edge recreation when table properties change
     ]);
 
     useEffect(() => {
@@ -997,6 +998,19 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables }) => {
                     width: event.data.table.width,
                 };
 
+                // Trigger a dimension change to force React Flow to update the node
+                onNodesChangeHandler([
+                    {
+                        id: event.data.id,
+                        type: 'dimensions',
+                        dimensions: {
+                            width: event.data.table.width,
+                            height: node.measured?.height || 0,
+                        },
+                        resizing: true, // Set resizing flag to ensure the change is processed
+                    } as NodeDimensionChange,
+                ]);
+
                 newOverlappingGraph = findTableOverlapping(
                     {
                         node: {
@@ -1051,7 +1065,14 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables }) => {
                 setOverlapGraph(overlappingTablesInDiagram);
             }
         },
-        [overlapGraph, setOverlapGraph, getNode, nodes, filteredSchemas]
+        [
+            overlapGraph,
+            setOverlapGraph,
+            getNode,
+            nodes,
+            filteredSchemas,
+            onNodesChangeHandler,
+        ]
     );
 
     events.useSubscription(eventConsumer);


### PR DESCRIPTION
This PR fixing - this issue of resizing table width: 

before resize: 
<img width="996" height="396" alt="Snip20250730_199" src="https://github.com/user-attachments/assets/93e55c30-26fe-407e-8245-df9bfa57786a" />
after resize: 
<img width="1036" height="464" alt="Snip20250730_201" src="https://github.com/user-attachments/assets/f46cbea4-5f43-41ea-9231-e02ab70499b9" />
