### PR TITLE
fix(custom-types): Make schema optional

### DIFF
--- a/src/lib/domain/db-custom-type.ts
+++ b/src/lib/domain/db-custom-type.ts
@@ -30,7 +30,7 @@ export const dbCustomTypeFieldSchema = z.object({
 
 export const dbCustomTypeSchema: z.ZodType<DBCustomType> = z.object({
     id: z.string(),
-    schema: z.string(),
+    schema: z.string().optional(),
     name: z.string(),
     kind: z.nativeEnum(DBCustomTypeKind),
     values: z.array(z.string()).optional(),


### PR DESCRIPTION
The schema is optional in practice for custom types (as seen in the TS types above), and not always included in exports.