### PR TITLE
fix(cla): Harden action

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   actions: write
-  contents: write # this can be 'read' if the signatures are in remote repository
+  contents: read
   pull-requests: write
   statuses: write
 


### PR DESCRIPTION
The CLA action does not need contents: write permission. Limit it to read for security.