### PR TITLE
feat: Add Docker volume support for storing and loading diagrams and many more features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,15 @@ RUN echo "VITE_OPENAI_API_KEY=${VITE_OPENAI_API_KEY}" > .env && \
 
 RUN npm run build
 
-FROM nginx:stable-alpine AS production
+FROM node:22-alpine AS production
 
-COPY --from=builder /usr/src/app/dist /usr/share/nginx/html
-COPY ./default.conf.template /etc/nginx/conf.d/default.conf.template
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+COPY --from=builder /usr/src/app/dist ./dist
+COPY server.mjs ./
 
+VOLUME ["/data"]
 EXPOSE 80
 
-ENTRYPOINT ["/entrypoint.sh"]
+CMD ["node", "server.mjs"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
                 "clsx": "^2.1.1",
                 "cmdk": "^1.0.0",
                 "dexie": "^4.0.8",
+                "express": "^4.19.2",
                 "fast-deep-equal": "^3.1.3",
                 "html-to-image": "^1.11.11",
                 "i18next": "^23.14.0",
@@ -4960,6 +4961,19 @@
                 "d3-zoom": "^3.0.0"
             }
         },
+        "node_modules/accepts": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+            "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "~2.1.34",
+                "negotiator": "0.6.3"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/acorn": {
             "version": "8.14.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -5239,6 +5253,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/array-flatten": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+            "license": "MIT"
+        },
         "node_modules/array-includes": {
             "version": "3.1.8",
             "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.8.tgz",
@@ -5485,6 +5505,45 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/body-parser": {
+            "version": "1.20.3",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+            "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "content-type": "~1.0.5",
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.4.24",
+                "on-finished": "2.4.1",
+                "qs": "6.13.0",
+                "raw-body": "2.5.2",
+                "type-is": "~1.6.18",
+                "unpipe": "1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
+            }
+        },
+        "node_modules/body-parser/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/body-parser/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "license": "MIT"
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -5541,6 +5600,15 @@
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
+        "node_modules/bytes": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/cac": {
             "version": "6.7.14",
             "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -5574,7 +5642,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
             "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -5588,7 +5655,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
             "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
@@ -5876,6 +5942,27 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/content-disposition": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+            "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/content-type": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -5891,6 +5978,12 @@
             "engines": {
                 "node": ">=18"
             }
+        },
+        "node_modules/cookie-signature": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+            "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+            "license": "MIT"
         },
         "node_modules/copy-to-clipboard": {
             "version": "3.3.3",
@@ -6221,6 +6314,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/depd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/dequal": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -6228,6 +6330,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/destroy": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
             }
         },
         "node_modules/detect-node-es": {
@@ -6285,7 +6397,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
@@ -6302,6 +6413,12 @@
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "license": "MIT"
         },
+        "node_modules/ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "license": "MIT"
+        },
         "node_modules/electron-to-chromium": {
             "version": "1.5.90",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.90.tgz",
@@ -6314,6 +6431,15 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
             "license": "MIT"
+        },
+        "node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/entities": {
             "version": "4.5.0",
@@ -6407,7 +6533,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -6417,7 +6542,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -6462,7 +6586,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
             "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -6563,6 +6686,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "license": "MIT"
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
@@ -6955,6 +7084,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/eventsource-parser": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-1.1.2.tgz",
@@ -6973,6 +7111,76 @@
             "engines": {
                 "node": ">=12.0.0"
             }
+        },
+        "node_modules/express": {
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+            "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "~1.3.8",
+                "array-flatten": "1.1.1",
+                "body-parser": "1.20.3",
+                "content-disposition": "0.5.4",
+                "content-type": "~1.0.4",
+                "cookie": "0.7.1",
+                "cookie-signature": "1.0.6",
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "encodeurl": "~2.0.0",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "finalhandler": "1.3.1",
+                "fresh": "0.5.2",
+                "http-errors": "2.0.0",
+                "merge-descriptors": "1.0.3",
+                "methods": "~1.1.2",
+                "on-finished": "2.4.1",
+                "parseurl": "~1.3.3",
+                "path-to-regexp": "0.1.12",
+                "proxy-addr": "~2.0.7",
+                "qs": "6.13.0",
+                "range-parser": "~1.2.1",
+                "safe-buffer": "5.2.1",
+                "send": "0.19.0",
+                "serve-static": "1.16.2",
+                "setprototypeof": "1.2.0",
+                "statuses": "2.0.1",
+                "type-is": "~1.6.18",
+                "utils-merge": "1.0.1",
+                "vary": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express/node_modules/cookie": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+            "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/express/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/express/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -7081,6 +7289,39 @@
                 "node": ">=8"
             }
         },
+        "node_modules/finalhandler": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+            "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "2.6.9",
+                "encodeurl": "~2.0.0",
+                "escape-html": "~1.0.3",
+                "on-finished": "2.4.1",
+                "parseurl": "~1.3.3",
+                "statuses": "2.0.1",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/finalhandler/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/finalhandler/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "license": "MIT"
+        },
         "node_modules/find-up": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -7151,6 +7392,15 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/forwarded": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/fraction.js": {
             "version": "4.3.7",
             "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -7190,6 +7440,15 @@
                 "react-dom": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/fresh": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/fsevents": {
@@ -7270,7 +7529,6 @@
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
             "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
@@ -7304,7 +7562,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "dunder-proto": "^1.0.1",
@@ -7438,7 +7695,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -7542,7 +7798,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -7593,6 +7848,22 @@
             "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
             "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA==",
             "license": "MIT"
+        },
+        "node_modules/http-errors": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+            "license": "MIT",
+            "dependencies": {
+                "depd": "2.0.0",
+                "inherits": "2.0.4",
+                "setprototypeof": "1.2.0",
+                "statuses": "2.0.1",
+                "toidentifier": "1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/husky": {
             "version": "9.1.7",
@@ -7648,6 +7919,18 @@
                 "@babel/runtime": "^7.23.2"
             }
         },
+        "node_modules/iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -7695,6 +7978,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "license": "ISC"
+        },
         "node_modules/inline-style-prefixer": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.1.tgz",
@@ -7732,6 +8021,15 @@
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.0.0"
+            }
+        },
+        "node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
             }
         },
         "node_modules/is-array-buffer": {
@@ -8524,7 +8822,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -8536,6 +8833,24 @@
             "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
             "license": "CC0-1.0"
         },
+        "node_modules/media-typer": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/merge-descriptors": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+            "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -8543,6 +8858,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/methods": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+            "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/micromatch": {
@@ -8558,11 +8882,22 @@
                 "node": ">=8.6"
             }
         },
+        "node_modules/mime": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "license": "MIT",
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/mime-db": {
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -8572,7 +8907,6 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mime-db": "1.52.0"
@@ -8684,7 +9018,6 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/mz": {
@@ -8742,6 +9075,15 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/negotiator": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/node-releases": {
             "version": "2.0.19",
@@ -8804,7 +9146,6 @@
             "version": "1.13.3",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
             "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -8895,6 +9236,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/open": {
@@ -9002,6 +9355,15 @@
                 "node": ">=6"
             }
         },
+        "node_modules/parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/parsimmon": {
             "version": "1.18.1",
             "resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.18.1.tgz",
@@ -9054,6 +9416,12 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
             "license": "ISC"
+        },
+        "node_modules/path-to-regexp": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+            "license": "MIT"
         },
         "node_modules/pathe": {
             "version": "2.0.3",
@@ -9407,6 +9775,19 @@
                 "react-is": "^16.13.1"
             }
         },
+        "node_modules/proxy-addr": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "license": "MIT",
+            "dependencies": {
+                "forwarded": "0.2.0",
+                "ipaddr.js": "1.9.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -9415,6 +9796,21 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/qs": {
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "side-channel": "^1.0.6"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/queue-microtask": {
@@ -9436,6 +9832,30 @@
                 }
             ],
             "license": "MIT"
+        },
+        "node_modules/range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/raw-body": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.4.24",
+                "unpipe": "1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/react": {
             "version": "18.3.1",
@@ -9992,6 +10412,26 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/safe-push-apply": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -10026,6 +10466,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "license": "MIT"
         },
         "node_modules/scheduler": {
             "version": "0.23.2",
@@ -10065,6 +10511,69 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/send": {
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "2.0.0",
+                "mime": "1.6.0",
+                "ms": "2.1.3",
+                "on-finished": "2.4.1",
+                "range-parser": "~1.2.1",
+                "statuses": "2.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/send/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/send/node_modules/debug/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "license": "MIT"
+        },
+        "node_modules/send/node_modules/encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/serve-static": {
+            "version": "1.16.2",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+            "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "~2.0.0",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.3",
+                "send": "0.19.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
             }
         },
         "node_modules/set-cookie-parser": {
@@ -10131,6 +10640,12 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/setprototypeof": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "license": "ISC"
+        },
         "node_modules/shallow-equal": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
@@ -10168,7 +10683,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
             "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -10188,7 +10702,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
             "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -10205,7 +10718,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
             "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -10224,7 +10736,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
             "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -10361,6 +10872,15 @@
             "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
             "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
             "license": "MIT"
+        },
+        "node_modules/statuses": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/std-env": {
             "version": "3.9.0",
@@ -10991,6 +11511,15 @@
             "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
             "license": "MIT"
         },
+        "node_modules/toidentifier": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
         "node_modules/totalist": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -11049,6 +11578,19 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/type-is": {
+            "version": "1.6.18",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+            "license": "MIT",
+            "dependencies": {
+                "media-typer": "0.3.0",
+                "mime-types": "~2.1.24"
+            },
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/typed-array-buffer": {
@@ -11168,6 +11710,15 @@
             "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/unplugin": {
             "version": "1.16.1",
@@ -11304,6 +11855,24 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "license": "MIT"
+        },
+        "node_modules/utils-merge": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+            "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/vaul": {
             "version": "0.9.9",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
         "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
         "lint:fix": "npm run lint -- --fix",
         "preview": "vite preview",
-        "prepare": "husky",
+        "prepare": "husky || true",
         "test": "vitest",
         "test:ci": "vitest run --reporter=verbose --bail=1",
         "test:ui": "vitest --ui",
-        "test:coverage": "vitest --coverage"
+        "test:coverage": "vitest --coverage",
+        "start": "node server.mjs"
     },
     "dependencies": {
         "@ai-sdk/openai": "^0.0.51",
@@ -72,7 +73,8 @@
         "tailwindcss-animate": "^1.0.7",
         "timeago-react": "^3.0.6",
         "vaul": "^0.9.1",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "express": "^4.19.2"
     },
     "devDependencies": {
         "@eslint/compat": "^1.2.4",

--- a/server.mjs
+++ b/server.mjs
@@ -1,0 +1,147 @@
+import express from 'express';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DATA_DIR = '/data';
+
+const app = express();
+app.use(express.json({ limit: '10mb' }));
+
+app.use(express.static(path.join(__dirname, 'dist')));
+
+const diagramFile = (id) => path.join(DATA_DIR, `${id}.json`);
+const isDiagramFile = (file) => /^[a-z0-9]{12}\.json$/.test(file);
+const sendIndexHtml = (res) => {
+    res.sendFile(path.join(__dirname, 'dist', 'index.html'));
+};
+
+const normalizeDiagram = (diagram) => ({
+    ...diagram,
+    tables: (diagram.tables ?? []).map((table) => ({
+        ...table,
+        x: table.x ?? 0,
+        y: table.y ?? 0,
+    })),
+    relationships: diagram.relationships ?? [],
+    dependencies: diagram.dependencies ?? [],
+    areas: (diagram.areas ?? []).map((area) => ({
+        ...area,
+        x: area.x ?? 0,
+        y: area.y ?? 0,
+        width: area.width ?? 0,
+        height: area.height ?? 0,
+    })),
+    customTypes: diagram.customTypes ?? [],
+});
+
+const writeJsonAtomic = async (filePath, data) => {
+    const json = JSON.stringify(data, null, 2);
+    const tempPath = `${filePath}.tmp`;
+    const handle = await fs.open(tempPath, 'w');
+    try {
+        await handle.writeFile(json, 'utf-8');
+        await handle.sync();
+    } finally {
+        await handle.close();
+    }
+    await fs.rename(tempPath, filePath);
+};
+
+const wantsHtml = (req) => req.headers.accept?.includes('text/html');
+
+app.get('/diagram', async (req, res) => {
+    if (wantsHtml(req)) {
+        return sendIndexHtml(res);
+    }
+    try {
+        const files = await fs.readdir(DATA_DIR);
+        const diagrams = [];
+        for (const file of files) {
+            if (!isDiagramFile(file)) {
+                continue;
+            }
+            try {
+                const content = await fs.readFile(
+                    path.join(DATA_DIR, file),
+                    'utf-8'
+                );
+                const data = normalizeDiagram(JSON.parse(content));
+                data.id = path.basename(file, '.json');
+                diagrams.push(data);
+            } catch {
+                // Ignore invalid JSON or files that can't be read
+            }
+        }
+        res.json(diagrams);
+    } catch {
+        res.json([]);
+    }
+});
+
+app.get('/diagram/:id', async (req, res) => {
+    if (wantsHtml(req)) {
+        return sendIndexHtml(res);
+    }
+    try {
+        const content = await fs.readFile(diagramFile(req.params.id), 'utf-8');
+        const data = normalizeDiagram(JSON.parse(content));
+        data.id = req.params.id;
+        res.json(data);
+    } catch {
+        res.status(404).send('Not found');
+    }
+});
+
+app.put('/diagram/:id', async (req, res) => {
+    try {
+        await fs.mkdir(DATA_DIR, { recursive: true });
+        const diagram = normalizeDiagram({ ...req.body, id: req.params.id });
+        await writeJsonAtomic(diagramFile(req.params.id), diagram);
+        res.status(204).end();
+    } catch {
+        res.status(500).send('Failed to save');
+    }
+});
+
+app.delete('/diagram/:id', async (req, res) => {
+    try {
+        await fs.unlink(diagramFile(req.params.id));
+        res.status(204).end();
+    } catch {
+        res.status(404).end();
+    }
+});
+
+app.get('/config', async (_req, res) => {
+    try {
+        const content = await fs.readFile(
+            path.join(DATA_DIR, 'config.json'),
+            'utf-8'
+        );
+        res.type('application/json').send(content);
+    } catch {
+        res.json({ defaultDiagramId: '' });
+    }
+});
+
+app.put('/config', async (req, res) => {
+    try {
+        await fs.mkdir(DATA_DIR, { recursive: true });
+        const filePath = path.join(DATA_DIR, 'config.json');
+        await writeJsonAtomic(filePath, req.body);
+        res.status(204).end();
+    } catch {
+        res.status(500).send('Failed to save config');
+    }
+});
+
+app.use((_req, res) => {
+    res.sendFile(path.join(__dirname, 'dist', 'index.html'));
+});
+
+app.listen(80, () => {
+    console.log('ChartDB server listening on port 80');
+});

--- a/src/context/chartdb-context/chartdb-provider.tsx
+++ b/src/context/chartdb-context/chartdb-provider.tsx
@@ -292,12 +292,10 @@ export const ChartDBProvider: React.FC<
             setTables((currentTables) => [...currentTables, ...tablesToAdd]);
             const updatedAt = new Date();
             setDiagramUpdatedAt(updatedAt);
-            await Promise.all([
-                db.updateDiagram({ id: diagramId, attributes: { updatedAt } }),
-                ...tablesToAdd.map((table) =>
-                    db.addTable({ diagramId, table })
-                ),
-            ]);
+            await db.modifyDiagram(diagramId, (d) => {
+                d.tables = [...(d.tables ?? []), ...tablesToAdd];
+                d.updatedAt = updatedAt;
+            });
 
             events.emit({
                 action: 'add_tables',
@@ -1055,30 +1053,31 @@ export const ChartDBProvider: React.FC<
 
     const addRelationships: ChartDBContext['addRelationships'] = useCallback(
         async (
-            relationships: DBRelationship[],
+            relationshipsToAdd: DBRelationship[],
             options = { updateHistory: true }
         ) => {
             setRelationships((currentRelationships) => [
                 ...currentRelationships,
-                ...relationships,
+                ...relationshipsToAdd,
             ]);
 
             const updatedAt = new Date();
             setDiagramUpdatedAt(updatedAt);
 
-            await Promise.all([
-                ...relationships.map((relationship) =>
-                    db.addRelationship({ diagramId, relationship })
-                ),
-                db.updateDiagram({ id: diagramId, attributes: { updatedAt } }),
-            ]);
+            await db.modifyDiagram(diagramId, (d) => {
+                d.relationships = [
+                    ...(d.relationships ?? []),
+                    ...relationshipsToAdd,
+                ];
+                d.updatedAt = updatedAt;
+            });
 
             if (options.updateHistory) {
                 addUndoAction({
                     action: 'addRelationships',
-                    redoData: { relationships },
+                    redoData: { relationships: relationshipsToAdd },
                     undoData: {
-                        relationshipIds: relationships.map((r) => r.id),
+                        relationshipIds: relationshipsToAdd.map((r) => r.id),
                     },
                 });
                 resetRedoStack();

--- a/src/context/dialog-context/dialog-context.tsx
+++ b/src/context/dialog-context/dialog-context.tsx
@@ -10,6 +10,7 @@ import type { CreateRelationshipDialogProps } from '@/dialogs/create-relationshi
 import type { ImportDBMLDialogProps } from '@/dialogs/import-dbml-dialog/import-dbml-dialog';
 import type { OpenDiagramDialogProps } from '@/dialogs/open-diagram-dialog/open-diagram-dialog';
 import type { CreateDiagramDialogProps } from '@/dialogs/create-diagram-dialog/create-diagram-dialog';
+import type { ShareTableDialogProps } from '@/dialogs/share-table-dialog/share-table-dialog';
 
 export interface DialogContext {
     // Create diagram dialog
@@ -73,6 +74,12 @@ export interface DialogContext {
         params?: Omit<ImportDBMLDialogProps, 'dialog'>
     ) => void;
     closeImportDBMLDialog: () => void;
+
+    // Share table dialog
+    openShareTableDialog: (
+        params: Omit<ShareTableDialogProps, 'dialog'>
+    ) => void;
+    closeShareTableDialog: () => void;
 }
 
 export const dialogContext = createContext<DialogContext>({
@@ -98,4 +105,6 @@ export const dialogContext = createContext<DialogContext>({
     closeImportDiagramDialog: emptyFn,
     openImportDBMLDialog: emptyFn,
     closeImportDBMLDialog: emptyFn,
+    openShareTableDialog: emptyFn,
+    closeShareTableDialog: emptyFn,
 });

--- a/src/context/dialog-context/dialog-provider.tsx
+++ b/src/context/dialog-context/dialog-provider.tsx
@@ -22,6 +22,8 @@ import { ExportDiagramDialog } from '@/dialogs/export-diagram-dialog/export-diag
 import { ImportDiagramDialog } from '@/dialogs/import-diagram-dialog/import-diagram-dialog';
 import type { ImportDBMLDialogProps } from '@/dialogs/import-dbml-dialog/import-dbml-dialog';
 import { ImportDBMLDialog } from '@/dialogs/import-dbml-dialog/import-dbml-dialog';
+import type { ShareTableDialogProps } from '@/dialogs/share-table-dialog/share-table-dialog';
+import { ShareTableDialog } from '@/dialogs/share-table-dialog/share-table-dialog';
 
 export const DialogProvider: React.FC<React.PropsWithChildren> = ({
     children,
@@ -137,6 +139,20 @@ export const DialogProvider: React.FC<React.PropsWithChildren> = ({
     const [importDBMLDialogParams, setImportDBMLDialogParams] =
         useState<Omit<ImportDBMLDialogProps, 'dialog'>>();
 
+    // Share table dialog
+    const [openShareTableDialog, setOpenShareTableDialog] = useState(false);
+    const [shareTableDialogParams, setShareTableDialogParams] = useState<
+        Omit<ShareTableDialogProps, 'dialog'>
+    >({ tableId: '' });
+    const openShareTableDialogHandler: DialogContext['openShareTableDialog'] =
+        useCallback(
+            (params) => {
+                setShareTableDialogParams(params);
+                setOpenShareTableDialog(true);
+            },
+            [setOpenShareTableDialog]
+        );
+
     return (
         <dialogContext.Provider
             value={{
@@ -170,6 +186,8 @@ export const DialogProvider: React.FC<React.PropsWithChildren> = ({
                     setOpenImportDBMLDialog(true);
                 },
                 closeImportDBMLDialog: () => setOpenImportDBMLDialog(false),
+                openShareTableDialog: openShareTableDialogHandler,
+                closeShareTableDialog: () => setOpenShareTableDialog(false),
             }}
         >
             {children}
@@ -207,6 +225,10 @@ export const DialogProvider: React.FC<React.PropsWithChildren> = ({
             <ImportDBMLDialog
                 dialog={{ open: openImportDBMLDialog }}
                 {...importDBMLDialogParams}
+            />
+            <ShareTableDialog
+                dialog={{ open: openShareTableDialog }}
+                {...shareTableDialogParams}
             />
         </dialogContext.Provider>
     );

--- a/src/context/history-context/history-provider.tsx
+++ b/src/context/history-context/history-provider.tsx
@@ -174,11 +174,9 @@ export const HistoryProvider: React.FC<React.PropsWithChildren> = ({
             removeTables: async ({
                 undoData: { tables, relationships, dependencies },
             }) => {
-                await Promise.all([
-                    addTables(tables, { updateHistory: false }),
-                    addRelationships(relationships, { updateHistory: false }),
-                    addDependencies(dependencies, { updateHistory: false }),
-                ]);
+                await addTables(tables, { updateHistory: false });
+                await addRelationships(relationships, { updateHistory: false });
+                await addDependencies(dependencies, { updateHistory: false });
             },
             updateTable: ({ undoData: { tableId, table } }) => {
                 return updateTable(tableId, table, { updateHistory: false });
@@ -229,14 +227,12 @@ export const HistoryProvider: React.FC<React.PropsWithChildren> = ({
             updateTablesState: async ({
                 undoData: { tables, relationships, dependencies },
             }) => {
-                await Promise.all([
-                    updateTablesState(() => tables, {
-                        updateHistory: false,
-                        forceOverride: true,
-                    }),
-                    addRelationships(relationships, { updateHistory: false }),
-                    addDependencies(dependencies, { updateHistory: false }),
-                ]);
+                await updateTablesState(() => tables, {
+                    updateHistory: false,
+                    forceOverride: true,
+                });
+                await addRelationships(relationships, { updateHistory: false });
+                await addDependencies(dependencies, { updateHistory: false });
             },
             addIndex: ({ undoData: { tableId, indexId } }) => {
                 return removeIndex(tableId, indexId, { updateHistory: false });

--- a/src/context/keyboard-shortcuts-context/keyboard-shortcuts-provider.tsx
+++ b/src/context/keyboard-shortcuts-context/keyboard-shortcuts-provider.tsx
@@ -7,7 +7,7 @@ import {
 } from './keyboard-shortcuts';
 import { useHistory } from '@/hooks/use-history';
 import { useDialog } from '@/hooks/use-dialog';
-import { useChartDB } from '@/hooks/use-chartdb';
+import { useSaveDiagram } from '@/hooks/use-save-diagram';
 import { useLayout } from '@/hooks/use-layout';
 import { useReactFlow } from '@xyflow/react';
 
@@ -16,7 +16,7 @@ export const KeyboardShortcutsProvider: React.FC<React.PropsWithChildren> = ({
 }) => {
     const { redo, undo } = useHistory();
     const { openOpenDiagramDialog } = useDialog();
-    const { updateDiagramUpdatedAt } = useChartDB();
+    const { saveDiagram } = useSaveDiagram();
     const { toggleSidePanel } = useLayout();
     const { fitView } = useReactFlow();
 
@@ -48,11 +48,11 @@ export const KeyboardShortcutsProvider: React.FC<React.PropsWithChildren> = ({
     useHotkeys(
         keyboardShortcutsForOS[KeyboardShortcutAction.SAVE_DIAGRAM]
             .keyCombination,
-        updateDiagramUpdatedAt,
+        saveDiagram,
         {
             preventDefault: true,
         },
-        [updateDiagramUpdatedAt]
+        [saveDiagram]
     );
     useHotkeys(
         keyboardShortcutsForOS[KeyboardShortcutAction.TOGGLE_SIDE_PANEL]

--- a/src/context/storage-context/storage-context.tsx
+++ b/src/context/storage-context/storage-context.tsx
@@ -45,6 +45,10 @@ export interface StorageContext {
         id: string;
         attributes: Partial<Diagram>;
     }) => Promise<void>;
+    modifyDiagram: (
+        diagramId: string,
+        modifyFn: (diagram: Diagram) => void
+    ) => Promise<void>;
     deleteDiagram: (id: string) => Promise<void>;
 
     // Table operations
@@ -149,6 +153,7 @@ export const storageInitialValue: StorageContext = {
     listDiagrams: emptyFn,
     getDiagram: emptyFn,
     updateDiagram: emptyFn,
+    modifyDiagram: emptyFn,
     deleteDiagram: emptyFn,
 
     addTable: emptyFn,

--- a/src/dialogs/import-database-dialog/import-database-dialog.tsx
+++ b/src/dialogs/import-database-dialog/import-database-dialog.tsx
@@ -289,19 +289,15 @@ export const ImportDatabaseDialog: React.FC<ImportDatabaseDialogProps> = ({
 
         if (!(await shouldRemove)) return;
 
-        await Promise.all([
-            removeTables(tableIdsToRemove, { updateHistory: false }),
-            removeRelationships(relationshipIdsToRemove, {
-                updateHistory: false,
-            }),
-        ]);
+        await removeTables(tableIdsToRemove, { updateHistory: false });
+        await removeRelationships(relationshipIdsToRemove, {
+            updateHistory: false,
+        });
 
-        await Promise.all([
-            addTables(diagram.tables ?? [], { updateHistory: false }),
-            addRelationships(diagram.relationships ?? [], {
-                updateHistory: false,
-            }),
-        ]);
+        await addTables(diagram.tables ?? [], { updateHistory: false });
+        await addRelationships(diagram.relationships ?? [], {
+            updateHistory: false,
+        });
 
         if (currentDatabaseType === DatabaseType.GENERIC) {
             await updateDatabaseType(databaseType);

--- a/src/dialogs/import-dbml-dialog/import-dbml-dialog.tsx
+++ b/src/dialogs/import-dbml-dialog/import-dbml-dialog.tsx
@@ -223,23 +223,19 @@ Ref: comments.user_id > users.id // Each comment is written by one user`;
                 })
                 .map((relationship) => relationship.id);
 
-            // Remove existing items
-            await Promise.all([
-                removeTables(tableIdsToRemove, { updateHistory: false }),
-                removeRelationships(relationshipIdsToRemove, {
-                    updateHistory: false,
-                }),
-            ]);
+            // Remove existing items sequentially to avoid race conditions
+            await removeTables(tableIdsToRemove, { updateHistory: false });
+            await removeRelationships(relationshipIdsToRemove, {
+                updateHistory: false,
+            });
 
-            // Add new items
-            await Promise.all([
-                addTables(importedDiagram.tables ?? [], {
-                    updateHistory: false,
-                }),
-                addRelationships(importedDiagram.relationships ?? [], {
-                    updateHistory: false,
-                }),
-            ]);
+            // Add new items sequentially so diagram writes don't clobber each other
+            await addTables(importedDiagram.tables ?? [], {
+                updateHistory: false,
+            });
+            await addRelationships(importedDiagram.relationships ?? [], {
+                updateHistory: false,
+            });
             setReorder(true);
             closeImportDBMLDialog();
         } catch (e) {

--- a/src/dialogs/open-diagram-dialog/open-diagram-dialog.tsx
+++ b/src/dialogs/open-diagram-dialog/open-diagram-dialog.tsx
@@ -37,7 +37,7 @@ export const OpenDiagramDialog: React.FC<OpenDiagramDialogProps> = ({
     dialog,
     canClose = true,
 }) => {
-    const { closeOpenDiagramDialog } = useDialog();
+    const { closeOpenDiagramDialog, openCreateDiagramDialog } = useDialog();
     const { t } = useTranslation();
     const { updateConfig } = useConfig();
     const navigate = useNavigate();
@@ -117,6 +117,11 @@ export const OpenDiagramDialog: React.FC<OpenDiagramDialogProps> = ({
         },
         [openDiagram, closeOpenDiagramDialog]
     );
+
+    const startNewDiagram = useCallback(() => {
+        closeOpenDiagramDialog();
+        openCreateDiagramDialog();
+    }, [closeOpenDiagramDialog, openCreateDiagramDialog]);
 
     const onFocusHandler = useDebounce(
         (diagramId: string) => setSelectedDiagramId(diagramId),
@@ -254,15 +259,23 @@ export const OpenDiagramDialog: React.FC<OpenDiagramDialogProps> = ({
                     ) : (
                         <div />
                     )}
-                    <DialogClose asChild>
-                        <Button
-                            type="submit"
-                            disabled={!selectedDiagramId}
-                            onClick={() => openDiagram(selectedDiagramId ?? '')}
-                        >
-                            {t('open_diagram_dialog.open')}
+                    <div className="flex gap-2">
+                        <Button type="button" onClick={startNewDiagram}>
+                            {t('open_diagram_dialog.start_new')}
                         </Button>
-                    </DialogClose>
+                        <DialogClose asChild>
+                            <Button
+                                type="submit"
+                                disabled={!selectedDiagramId}
+                                onClick={() => {
+                                    openDiagram(selectedDiagramId ?? '');
+                                    closeOpenDiagramDialog();
+                                }}
+                            >
+                                {t('open_diagram_dialog.open')}
+                            </Button>
+                        </DialogClose>
+                    </div>
                 </DialogFooter>
             </DialogContent>
         </Dialog>

--- a/src/dialogs/share-table-dialog/share-table-dialog.tsx
+++ b/src/dialogs/share-table-dialog/share-table-dialog.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import { useDialog } from '@/hooks/use-dialog';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogClose,
+} from '@/components/dialog/dialog';
+import type { BaseDialogProps } from '../common/base-dialog-props';
+import { useTranslation } from 'react-i18next';
+import { Input } from '@/components/input/input';
+import { Button } from '@/components/button/button';
+import { Copy } from 'lucide-react';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@/components/tooltip/tooltip';
+import { useToast } from '@/components/toast/use-toast';
+
+export interface ShareTableDialogProps extends BaseDialogProps {
+    tableId: string;
+}
+
+export const ShareTableDialog: React.FC<ShareTableDialogProps> = ({
+    dialog,
+    tableId,
+}) => {
+    const { closeShareTableDialog } = useDialog();
+    const { t } = useTranslation();
+    const { toast } = useToast();
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const shareUrl = useMemo(() => {
+        const url = new URL(window.location.href);
+        url.searchParams.set('clean', 'true');
+        url.searchParams.set('table', tableId);
+        return url.toString();
+    }, [tableId]);
+
+    useEffect(() => {
+        if (dialog.open) {
+            setTimeout(() => {
+                inputRef.current?.select();
+            }, 0);
+        }
+    }, [dialog.open]);
+
+    const handleCopy = async () => {
+        inputRef.current?.select();
+        try {
+            await navigator.clipboard.writeText(shareUrl);
+            toast({ title: t('copied') });
+        } catch {
+            // ignore error, selection already made
+        }
+    };
+
+    return (
+        <Dialog
+            {...dialog}
+            onOpenChange={(open) => {
+                if (!open) {
+                    closeShareTableDialog();
+                }
+            }}
+        >
+            <DialogContent className="sm:max-w-xl">
+                <DialogHeader>
+                    <DialogTitle>{t('share_table_dialog.title')}</DialogTitle>
+                    <DialogDescription>
+                        {t('share_table_dialog.description')}
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="flex items-center gap-2 py-4">
+                    <Input
+                        ref={inputRef}
+                        value={shareUrl}
+                        readOnly
+                        className="min-w-[400px] flex-1"
+                    />
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Button
+                                variant="secondary"
+                                onClick={handleCopy}
+                                className="shrink-0 p-2"
+                            >
+                                <Copy className="size-4" />
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            {t('copy_to_clipboard')}
+                        </TooltipContent>
+                    </Tooltip>
+                </div>
+                <DialogFooter className="sm:justify-end">
+                    <DialogClose asChild>
+                        <Button variant="outline">
+                            {t('share_table_dialog.close')}
+                        </Button>
+                    </DialogClose>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};

--- a/src/hooks/use-save-diagram.tsx
+++ b/src/hooks/use-save-diagram.tsx
@@ -1,0 +1,26 @@
+import { useCallback, useState } from 'react';
+import { useChartDB } from '@/hooks/use-chartdb';
+import { waitFor } from '@/lib/utils';
+import { diagramToStorageJSON } from '@/lib/export-import-utils';
+import type { Diagram } from '@/lib/domain/diagram';
+
+export const useSaveDiagram = () => {
+    const [isSaving, setIsSaving] = useState(false);
+    const { currentDiagram, updateDiagramData } = useChartDB();
+
+    const saveDiagram = useCallback(async () => {
+        setIsSaving(true);
+        await waitFor(1000);
+        try {
+            const diagram: Diagram = diagramToStorageJSON({
+                ...currentDiagram,
+                updatedAt: new Date(),
+            });
+            await updateDiagramData(diagram, { forceUpdateStorage: true });
+        } finally {
+            setIsSaving(false);
+        }
+    }, [currentDiagram, updateDiagramData]);
+
+    return { saveDiagram, isSaving };
+};

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -41,9 +41,8 @@ export const ar: LanguageTranslation = {
                 theme: 'المظهر',
                 show_dependencies: 'إظهار الاعتمادات',
                 hide_dependencies: 'إخفاء الاعتمادات',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'إظهار الخريطة المصغرة',
+                hide_minimap: 'إخفاء الخريطة المصغرة',
             },
             backup: {
                 backup: 'النسخ الاحتياطي',
@@ -114,6 +113,12 @@ export const ar: LanguageTranslation = {
         copy_to_clipboard: 'نسخ إلى الحافظة',
         copied: '!تم النسخ',
 
+        share_table_dialog: {
+            title: 'جدول مشاركة',
+            description: 'انسخ الرابط أدناه لمشاركة هذا الجدول.',
+            close: 'يغلق',
+        },
+
         side_panel: {
             view_all_options: '...عرض جميع الخيارات',
             tables_section: {
@@ -122,12 +127,10 @@ export const ar: LanguageTranslation = {
                 add_view: 'إضافة عرض',
                 filter: 'تصفية',
                 collapse: 'طي الكل',
-                // TODO: Translate
-                clear: 'Clear Filter',
-                no_results: 'No tables found matching your filter.',
-                // TODO: Translate
-                show_list: 'Show Table List',
-                show_dbml: 'Show DBML Editor',
+                clear: 'مرشح واضح',
+                no_results: 'لم يتم العثور على جداول مطابقة المرشح الخاص بك.',
+                show_list: 'عرض قائمة الجدول',
+                show_dbml: 'عرض محرر DBML',
 
                 table: {
                     fields: 'الحقول',
@@ -149,7 +152,6 @@ export const ar: LanguageTranslation = {
                         comments: 'تعليقات',
                         no_comments: 'لا يوجد تعليقات',
                         delete_field: 'حذف الحقل',
-                        // TODO: Translate
                         character_length: 'Max Length',
                         precision: 'الدقة',
                         scale: 'النطاق',
@@ -210,56 +212,53 @@ export const ar: LanguageTranslation = {
                     description: 'إنشاء علاقة للبدء',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
+                areas: 'المناطق',
+                add_area: 'إضافة المنطقة',
+                filter: 'فلتر',
+                clear: 'مرشح واضح',
+                no_results: 'لم يتم العثور على مناطق مطابقة المرشح الخاص بك.',
 
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: 'إجراءات المنطقة',
+                        edit_name: 'تحرير الاسم',
+                        delete_area: 'حذف المنطقة',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: 'لا مناطق',
+                    description: 'إنشاء منطقة للبدء',
                 },
             },
-
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: 'أنواع مخصصة',
+                filter: 'فلتر',
+                clear: 'مرشح واضح',
+                no_results:
+                    'لم يتم العثور على أنواع مخصصة مطابقة المرشح الخاص بك.',
                 empty_state: {
-                    title: 'No custom types',
+                    title: 'لا أنواع مخصصة',
                     description:
-                        'Custom types will appear here when they are available in your database',
+                        'ستظهر أنواع مخصصة هنا عندما تكون متوفرة في قاعدة البيانات الخاصة بك',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: 'عطوف',
+                    enum_values: 'قيم التعداد',
+                    composite_fields: 'الحقول',
+                    no_fields: 'لا توجد حقول محددة',
                     no_values: 'لم يتم تحديد قيم التعداد',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: 'اسم الحقل',
+                    field_type_placeholder: 'حدد النوع',
+                    add_field: 'إضافة الحقل',
+                    no_fields_tooltip: 'لا توجد حقول محددة لهذا النوع المخصص',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: 'الإجراءات',
+                        highlight_fields: 'تسليط الضوء على الحقول',
+                        delete_custom_type: 'يمسح',
+                        clear_field_highlight: 'تسليط الضوء واضح',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: 'حذف النوع',
                 },
             },
         },
@@ -273,7 +272,6 @@ export const ar: LanguageTranslation = {
             redo: 'إعادة',
             reorder_diagram: 'ترتيب تلقائي للرسم البياني',
             highlight_overlapping_tables: 'تمييز الجداول المتداخلة',
-            // TODO: Translate
             filter: 'Filter Tables',
             clear_custom_type_highlight: 'Clear highlight for "{{typeName}}"',
             custom_type_highlight_tooltip:
@@ -323,6 +321,7 @@ export const ar: LanguageTranslation = {
                 tables_count: 'الجداول',
             },
             cancel: 'إلغاء',
+            start_new: 'ابدأ بمخطط جديد',
             open: 'فتح',
 
             diagram_actions: {
@@ -393,7 +392,6 @@ export const ar: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'إلغاء',
             export: 'تصدير',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -453,7 +451,6 @@ export const ar: LanguageTranslation = {
             },
         },
         import_dbml_dialog: {
-            // TODO: Translate
             title: 'Import DBML',
             example_title: 'Import Example DBML',
             description: 'Import a database schema from DBML format.',
@@ -477,7 +474,6 @@ export const ar: LanguageTranslation = {
             new_table: 'جدول جديد',
             new_view: 'عرض جديد',
             new_relationship: 'علاقة جديدة',
-            // TODO: Translate
             new_area: 'New Area',
         },
 
@@ -485,7 +481,7 @@ export const ar: LanguageTranslation = {
             edit_table: 'تعديل الجدول',
             duplicate_table: 'نسخ الجدول',
             delete_table: 'حذف الجدول',
-            add_relationship: 'Add Relationship', // TODO: Translate
+            add_relationship: 'أضف العلاقة',
         },
 
         snap_to_grid_tooltip: '({{key}} مغنظة الشبكة (اضغط مع الاستمرار على',

--- a/src/i18n/locales/bn.ts
+++ b/src/i18n/locales/bn.ts
@@ -41,9 +41,8 @@ export const bn: LanguageTranslation = {
                 theme: 'থিম',
                 show_dependencies: 'নির্ভরতাগুলি দেখান',
                 hide_dependencies: 'নির্ভরতাগুলি লুকান',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'মিনি মানচিত্র দেখান',
+                hide_minimap: 'মিনি মানচিত্র লুকান',
             },
 
             backup: {
@@ -115,6 +114,12 @@ export const bn: LanguageTranslation = {
         copy_to_clipboard: 'ক্লিপবোর্ডে অনুলিপি করুন',
         copied: 'অনুলিপি সম্পন্ন!',
 
+        share_table_dialog: {
+            title: 'টেবিল ভাগ করুন',
+            description: 'এই টেবিলটি ভাগ করতে নীচের লিঙ্কটি অনুলিপি করুন।',
+            close: 'বন্ধ',
+        },
+
         side_panel: {
             view_all_options: 'সমস্ত বিকল্প দেখুন...',
             tables_section: {
@@ -123,12 +128,11 @@ export const bn: LanguageTranslation = {
                 add_view: 'ভিউ যোগ করুন',
                 filter: 'ফিল্টার',
                 collapse: 'সব ভাঁজ করুন',
-                // TODO: Translate
-                clear: 'Clear Filter',
-                no_results: 'No tables found matching your filter.',
-                // TODO: Translate
-                show_list: 'Show Table List',
-                show_dbml: 'Show DBML Editor',
+                clear: 'ফিল্টার সাফ করুন',
+                no_results:
+                    'আপনার ফিল্টারটির সাথে মিলে যাওয়ার কোনও টেবিল পাওয়া যায় নি।',
+                show_list: 'টেবিল তালিকা দেখান',
+                show_dbml: 'ডিবিএমএল সম্পাদক দেখান',
 
                 table: {
                     fields: 'ফিল্ড',
@@ -150,10 +154,8 @@ export const bn: LanguageTranslation = {
                         comments: 'মন্তব্য',
                         no_comments: 'কোনো মন্তব্য নেই',
                         delete_field: 'ফিল্ড মুছুন',
-                        // TODO: Translate
                         default_value: 'Default Value',
                         no_default: 'No default',
-                        // TODO: Translate
                         character_length: 'Max Length',
                         precision: 'নির্ভুলতা',
                         scale: 'স্কেল',
@@ -212,55 +214,55 @@ export const bn: LanguageTranslation = {
                     description: 'শুরু করতে একটি সম্পর্ক তৈরি করুন',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
+                areas: 'অঞ্চল',
+                add_area: 'অঞ্চল যুক্ত করুন',
+                filter: 'ফিল্টার',
+                clear: 'ফিল্টার সাফ করুন',
+                no_results:
+                    'আপনার ফিল্টারটির সাথে মিলে যাওয়া কোনও অঞ্চলই পাওয়া যায় নি।',
 
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: 'অঞ্চল ক্রিয়া',
+                        edit_name: 'নাম সম্পাদনা করুন',
+                        delete_area: 'অঞ্চল মুছুন',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: 'কোন অঞ্চল নেই',
+                    description: 'শুরু করার জন্য একটি অঞ্চল তৈরি করুন',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: 'কাস্টম প্রকার',
+                filter: 'ফিল্টার',
+                clear: 'ফিল্টার সাফ করুন',
+                no_results:
+                    'কোনও কাস্টম প্রকার আপনার ফিল্টারটির সাথে মিলে যায় না।',
                 empty_state: {
-                    title: 'No custom types',
+                    title: 'কোন কাস্টম প্রকার নেই',
                     description:
-                        'Custom types will appear here when they are available in your database',
+                        'কাস্টম প্রকারগুলি এখানে আপনার ডাটাবেসে উপলব্ধ থাকলে এখানে উপস্থিত হবে',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: 'দয়ালু',
+                    enum_values: 'এনাম মান',
+                    composite_fields: 'ক্ষেত্র',
+                    no_fields: 'কোনও ক্ষেত্র সংজ্ঞায়িত করা হয়নি',
                     no_values: 'কোন enum মান সংজ্ঞায়িত নেই',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: 'মাঠের নাম',
+                    field_type_placeholder: 'প্রকার নির্বাচন করুন',
+                    add_field: 'ক্ষেত্র যুক্ত করুন',
+                    no_fields_tooltip:
+                        'এই কাস্টম প্রকারের জন্য কোনও ক্ষেত্র সংজ্ঞায়িত করা হয়নি',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: 'ক্রিয়া',
+                        highlight_fields: 'ক্ষেত্রগুলি হাইলাইট করুন',
+                        delete_custom_type: 'মুছুন',
+                        clear_field_highlight: 'পরিষ্কার হাইলাইট',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: 'টাইপ মুছুন',
                 },
             },
         },
@@ -274,8 +276,6 @@ export const bn: LanguageTranslation = {
             redo: 'পুনরায় করুন',
             reorder_diagram: 'স্বয়ংক্রিয় ডায়াগ্রাম সাজান',
             highlight_overlapping_tables: 'ওভারল্যাপিং টেবিল হাইলাইট করুন',
-
-            // TODO: Translate
             clear_custom_type_highlight: 'Clear highlight for "{{typeName}}"',
             custom_type_highlight_tooltip:
                 'Highlighting "{{typeName}}" - Click to clear',
@@ -325,6 +325,7 @@ export const bn: LanguageTranslation = {
                 tables_count: 'টেবিল',
             },
             cancel: 'বাতিল করুন',
+            start_new: 'নতুন ডায়াগ্রাম দিয়ে শুরু করুন',
             open: 'খুলুন',
 
             diagram_actions: {
@@ -395,7 +396,6 @@ export const bn: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'বাতিল করুন',
             export: 'রপ্তানি করুন',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -457,7 +457,6 @@ export const bn: LanguageTranslation = {
                     'ডায়াগ্রাম JSON অবৈধ। অনুগ্রহ করে JSON পরীক্ষা করুন এবং আবার চেষ্টা করুন। সাহায্যের প্রয়োজন? support@chartdb.io-এ যোগাযোগ করুন।',
             },
         },
-        // TODO: Translate
         import_dbml_dialog: {
             example_title: 'Import Example DBML',
             title: 'Import DBML',
@@ -482,7 +481,6 @@ export const bn: LanguageTranslation = {
             new_table: 'নতুন টেবিল',
             new_view: 'নতুন ভিউ',
             new_relationship: 'নতুন সম্পর্ক',
-            // TODO: Translate
             new_area: 'New Area',
         },
 
@@ -490,7 +488,7 @@ export const bn: LanguageTranslation = {
             edit_table: 'টেবিল সম্পাদনা করুন',
             duplicate_table: 'টেবিল নকল করুন',
             delete_table: 'টেবিল মুছে ফেলুন',
-            add_relationship: 'Add Relationship', // TODO: Translate
+            add_relationship: 'সম্পর্ক যুক্ত করুন',
         },
 
         snap_to_grid_tooltip: 'গ্রিডে স্ন্যাপ করুন (অবস্থান {{key}})',

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -41,11 +41,9 @@ export const de: LanguageTranslation = {
                 theme: 'Stil',
                 show_dependencies: 'Abhängigkeiten anzeigen',
                 hide_dependencies: 'Abhängigkeiten ausblenden',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'Mini-Karte anzeigen',
+                hide_minimap: 'Mini-Karte ausblenden',
             },
-            // TODO: Translate
             backup: {
                 backup: 'Backup',
                 export_diagram: 'Export Diagram',
@@ -116,6 +114,13 @@ export const de: LanguageTranslation = {
         copy_to_clipboard: 'In die Zwischenablage kopieren',
         copied: 'Kopiert!',
 
+        share_table_dialog: {
+            title: 'Teile Tabelle',
+            description:
+                'Kopieren Sie den folgenden Link, um diese Tabelle zu teilen.',
+            close: 'Schließen',
+        },
+
         side_panel: {
             view_all_options: 'Alle Optionen anzeigen...',
             tables_section: {
@@ -124,12 +129,11 @@ export const de: LanguageTranslation = {
                 add_view: 'Ansicht hinzufügen',
                 filter: 'Filter',
                 collapse: 'Alle einklappen',
-                // TODO: Translate
-                clear: 'Clear Filter',
-                no_results: 'No tables found matching your filter.',
-                // TODO: Translate
-                show_list: 'Show Table List',
-                show_dbml: 'Show DBML Editor',
+                clear: 'Klaren Filter',
+                no_results:
+                    'Keine Tabellen gefunden, die Ihren Filter entsprechen.',
+                show_list: 'Tabellenliste anzeigen',
+                show_dbml: 'Zeigen Sie den DBML -Editor',
 
                 table: {
                     fields: 'Felder',
@@ -151,10 +155,8 @@ export const de: LanguageTranslation = {
                         comments: 'Kommentare',
                         no_comments: 'Keine Kommentare',
                         delete_field: 'Feld löschen',
-                        // TODO: Translate
                         default_value: 'Default Value',
                         no_default: 'No default',
-                        // TODO: Translate
                         character_length: 'Max Length',
                         precision: 'Präzision',
                         scale: 'Skalierung',
@@ -171,7 +173,7 @@ export const de: LanguageTranslation = {
                         change_schema: 'Schema ändern',
                         add_field: 'Feld hinzufügen',
                         add_index: 'Index hinzufügen',
-                        duplicate_table: 'Duplicate Table', // TODO: Translate
+                        duplicate_table: 'Doppelte Tabelle',
                         delete_table: 'Tabelle löschen',
                     },
                 },
@@ -213,55 +215,54 @@ export const de: LanguageTranslation = {
                     description: 'Erstellen Sie eine Beziehung, um zu beginnen',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
+                areas: 'Bereiche',
+                add_area: 'Bereich hinzufügen',
                 filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
+                clear: 'Klaren Filter',
+                no_results: 'Keine Bereiche, die Ihren Filter entsprechen.',
 
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: 'Gebietsaktionen',
+                        edit_name: 'Name bearbeiten',
+                        delete_area: 'Bereich löschen',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: 'Keine Bereiche',
+                    description: 'Erstellen Sie einen Bereich, um loszulegen',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
+                custom_types: 'Benutzerdefinierte Typen',
                 filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                clear: 'Klaren Filter',
+                no_results:
+                    'Keine benutzerdefinierten Typen, die Ihren Filter entsprechen.',
                 empty_state: {
-                    title: 'No custom types',
+                    title: 'Keine benutzerdefinierten Typen',
                     description:
-                        'Custom types will appear here when they are available in your database',
+                        'Benutzerdefinierte Typen werden hier angezeigt, wenn sie in Ihrer Datenbank verfügbar sind',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: 'Art',
+                    enum_values: 'Enum -Werte',
+                    composite_fields: 'Felder',
+                    no_fields: 'Keine Felder definiert',
                     no_values: 'Keine Enum-Werte definiert',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: 'Feldname',
+                    field_type_placeholder: 'Wählen Sie Typ',
+                    add_field: 'Feld hinzufügen',
+                    no_fields_tooltip:
+                        'Keine Felder, die für diesen benutzerdefinierten Typ definiert sind',
                     custom_type_actions: {
-                        title: 'Actions',
+                        title: 'Aktionen',
                         highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        delete_custom_type: 'Löschen',
+                        clear_field_highlight: 'Klares Highlight',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: 'Typ löschen',
                 },
             },
         },
@@ -280,7 +281,6 @@ export const de: LanguageTranslation = {
             custom_type_highlight_tooltip:
                 'Highlighting "{{typeName}}" - Click to clear',
             highlight_overlapping_tables: 'Überlappende Tabellen hervorheben',
-            // TODO: Translate
             filter: 'Filter Tables',
         },
 
@@ -311,7 +311,6 @@ export const de: LanguageTranslation = {
 
             cancel: 'Abbrechen',
             back: 'Zurück',
-            // TODO: Translate
             import_from_file: 'Import from File',
             empty_diagram: 'Leeres Diagramm',
             continue: 'Weiter',
@@ -328,6 +327,7 @@ export const de: LanguageTranslation = {
                 tables_count: 'Tabellen',
             },
             cancel: 'Abbrechen',
+            start_new: 'Mit einem neuen Diagramm starten',
             open: 'Öffnen',
 
             diagram_actions: {
@@ -398,7 +398,6 @@ export const de: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'Abbrechen',
             export: 'Exportieren',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -435,7 +434,6 @@ export const de: LanguageTranslation = {
             close: 'Nicht jetzt',
             confirm: 'Natürlich!',
         },
-        // TODO: Translate
         export_diagram_dialog: {
             title: 'Export Diagram',
             description: 'Choose the format for export:',
@@ -448,19 +446,16 @@ export const de: LanguageTranslation = {
                     'Something went wrong. Need help? support@chartdb.io',
             },
         },
-        // TODO: Translate
         import_diagram_dialog: {
-            title: 'Import Diagram',
+            title: 'Diagramm importieren',
             description: 'Paste the diagram JSON below:',
             cancel: 'Cancel',
             import: 'Import',
             error: {
-                title: 'Error importing diagram',
-                description:
-                    'The diagram JSON is invalid. Please check the JSON and try again. Need help? support@chartdb.io',
+                title: 'Fehler importieren Diagramm',
+                description: 'Das Diagramm JSON ist ungültig. ',
             },
         },
-        // TODO: Translate
         import_dbml_dialog: {
             example_title: 'Import Example DBML',
             title: 'Import DBML',
@@ -485,18 +480,15 @@ export const de: LanguageTranslation = {
             new_table: 'Neue Tabelle',
             new_view: 'Neue Ansicht',
             new_relationship: 'Neue Beziehung',
-            // TODO: Translate
             new_area: 'New Area',
         },
 
         table_node_context_menu: {
             edit_table: 'Tabelle bearbeiten',
-            duplicate_table: 'Duplicate Table', // TODO: Translate
+            duplicate_table: 'Doppelte Tabelle',
             delete_table: 'Tabelle löschen',
-            add_relationship: 'Add Relationship', // TODO: Translate
+            add_relationship: 'Beziehung hinzufügen',
         },
-
-        // TODO: Add translations
         snap_to_grid_tooltip: 'Snap to Grid (Hold {{key}})',
 
         tool_tips: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -113,6 +113,12 @@ export const en = {
         copy_to_clipboard: 'Copy to Clipboard',
         copied: 'Copied!',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: 'View all Options...',
             tables_section: {
@@ -316,6 +322,7 @@ export const en = {
                 tables_count: 'Tables',
             },
             cancel: 'Cancel',
+            start_new: 'Start with a new diagram',
             open: 'Open',
 
             diagram_actions: {

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -41,9 +41,8 @@ export const es: LanguageTranslation = {
                 theme: 'Tema',
                 show_dependencies: 'Mostrar dependencias',
                 hide_dependencies: 'Ocultar dependencias',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'Mostrar minimapa',
+                hide_minimap: 'Ocultar minimapa',
             },
             backup: {
                 backup: 'Respaldo',
@@ -56,7 +55,6 @@ export const es: LanguageTranslation = {
                 join_discord: 'Únete a nosotros en Discord',
             },
         },
-
         delete_diagram_alert: {
             title: 'Eliminar Diagrama',
             description:
@@ -64,7 +62,6 @@ export const es: LanguageTranslation = {
             cancel: 'Cancelar',
             delete: 'Eliminar',
         },
-
         clear_diagram_alert: {
             title: 'Limpiar Diagrama',
             description:
@@ -72,7 +69,6 @@ export const es: LanguageTranslation = {
             cancel: 'Cancelar',
             clear: 'Limpiar',
         },
-
         reorder_diagram_alert: {
             title: 'Organizar Diagrama Automáticamente',
             description:
@@ -80,7 +76,6 @@ export const es: LanguageTranslation = {
             reorder: 'Organizar Automáticamente',
             cancel: 'Cancelar',
         },
-
         copy_to_clipboard_toast: {
             unsupported: {
                 title: 'Copia fallida',
@@ -91,18 +86,15 @@ export const es: LanguageTranslation = {
                 description: 'Algo salió mal. Por favor, inténtelo de nuevo.',
             },
         },
-
         theme: {
             system: 'Sistema',
             light: 'Claro',
             dark: 'Oscuro',
         },
-
         zoom: {
             on: 'Encendido',
             off: 'Apagado',
         },
-
         last_saved: 'Último guardado',
         saved: 'Guardado',
         loading_diagram: 'Cargando diagrama...',
@@ -111,9 +103,13 @@ export const es: LanguageTranslation = {
         clear: 'Limpiar',
         show_more: 'Mostrar más',
         show_less: 'Mostrar menos',
-        copy_to_clipboard: 'Copy to Clipboard',
-        copied: 'Copied!',
-
+        copy_to_clipboard: 'Copiar en el portapapeles',
+        copied: '¡Copiado!',
+        share_table_dialog: {
+            title: 'Compartir tabla',
+            description: 'Copia el siguiente enlace para compartir esta tabla.',
+            close: 'Cerrar',
+        },
         side_panel: {
             view_all_options: 'Ver todas las opciones...',
             tables_section: {
@@ -122,13 +118,11 @@ export const es: LanguageTranslation = {
                 add_view: 'Agregar Vista',
                 filter: 'Filtrar',
                 collapse: 'Colapsar Todo',
-                // TODO: Translate
-                clear: 'Clear Filter',
-                no_results: 'No tables found matching your filter.',
-                // TODO: Translate
-                show_list: 'Show Table List',
-                show_dbml: 'Show DBML Editor',
-
+                clear: 'Limpiar filtro',
+                no_results:
+                    'No se han encontrado tablas que coincidan con tu filtro.',
+                show_list: 'Mostrar lista de tablas',
+                show_dbml: 'Mostrar editor DBML',
                 table: {
                     fields: 'Campos',
                     nullable: '¿Opcional?',
@@ -149,11 +143,9 @@ export const es: LanguageTranslation = {
                         comments: 'Comentarios',
                         no_comments: 'Sin comentarios',
                         delete_field: 'Eliminar Campo',
-                        // TODO: Translate
-                        default_value: 'Default Value',
-                        no_default: 'No default',
-                        // TODO: Translate
-                        character_length: 'Max Length',
+                        default_value: 'Valor por defecto',
+                        no_default: 'Ningún valor predeterminado',
+                        character_length: 'Longitud máxima',
                         precision: 'Precisión',
                         scale: 'Escala',
                     },
@@ -169,7 +161,7 @@ export const es: LanguageTranslation = {
                         change_schema: 'Cambiar Esquema',
                         add_field: 'Agregar Campo',
                         add_index: 'Agregar Índice',
-                        duplicate_table: 'Duplicate Table', // TODO: Translate
+                        duplicate_table: 'Duplicar Tabla',
                         delete_table: 'Eliminar Tabla',
                     },
                 },
@@ -211,59 +203,57 @@ export const es: LanguageTranslation = {
                     description: 'Crea una relación para comenzar',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
-
+                areas: 'Áreas',
+                add_area: 'Agregar Área',
+                filter: 'Filtrar',
+                clear: 'Limpiar filtro',
+                no_results:
+                    'No se han encontrado áreas que coincidan con tu filtro.',
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: 'Acciones de área',
+                        edit_name: 'Editar nombre',
+                        delete_area: 'Eliminar área',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: 'No hay áreas',
+                    description: 'Crea un área para empezar',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: 'Tipos personalizados',
+                filter: 'Filtrar',
+                clear: 'Limpiar filtro',
+                no_results:
+                    'No se han encontrado tipos personalizados que coincidan con tu filtro.',
                 empty_state: {
-                    title: 'No custom types',
+                    title: 'No hay tipos personalizados',
                     description:
-                        'Custom types will appear here when they are available in your database',
+                        'Los tipos personalizados aparecerán aquí cuando estén disponibles en su base de datos',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: 'Tipo',
+                    enum_values: 'Valores Enum',
+                    composite_fields: 'Campos',
+                    no_fields: 'Campo no definido.',
                     no_values: 'No hay valores de enum definidos',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: 'Nombre del campo',
+                    field_type_placeholder: 'Seleccionar tipo',
+                    add_field: 'Añadir Campo',
+                    no_fields_tooltip:
+                        'No hay campos definidos para este tipo personalizado',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: 'Acciones',
+                        highlight_fields: 'Resaltar campos',
+                        delete_custom_type: 'Eliminar',
+                        clear_field_highlight: 'Borrar resaltado',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: 'Eliminar tipo',
                 },
             },
         },
-
         toolbar: {
             zoom_in: 'Acercar',
             zoom_out: 'Alejar',
@@ -275,12 +265,10 @@ export const es: LanguageTranslation = {
             // TODO: Translate
             clear_custom_type_highlight: 'Clear highlight for "{{typeName}}"',
             custom_type_highlight_tooltip:
-                'Highlighting "{{typeName}}" - Click to clear',
+                'Resaltado "{{typeName}}" - Haga clic para borrar',
             highlight_overlapping_tables: 'Resaltar tablas superpuestas',
-            // TODO: Translate
-            filter: 'Filter Tables',
+            filter: 'Filtrar tablas',
         },
-
         new_diagram_dialog: {
             database_selection: {
                 title: '¿Cuál es tu Base de Datos?',
@@ -289,7 +277,6 @@ export const es: LanguageTranslation = {
                 check_examples_long: 'Ver Ejemplos',
                 check_examples_short: 'Ejemplos',
             },
-
             import_database: {
                 title: 'Importa tu Base de Datos',
                 database_edition: 'Edición de Base de Datos:',
@@ -305,16 +292,13 @@ export const es: LanguageTranslation = {
                 instructions_link: '¿Necesitas ayuda? mira cómo',
                 check_script_result: 'Revisa el resultado del script',
             },
-
             cancel: 'Cancelar',
             back: 'Atrás',
-            // TODO: Translate
-            import_from_file: 'Import from File',
+            import_from_file: 'Importar desde Archivo',
             empty_diagram: 'Diagrama vacío',
             continue: 'Continuar',
             import: 'Importar',
         },
-
         open_diagram_dialog: {
             title: 'Abrir Base de Datos',
             description:
@@ -326,15 +310,14 @@ export const es: LanguageTranslation = {
                 tables_count: 'Tablas',
             },
             cancel: 'Cancelar',
+            start_new: 'Empezar con un nuevo diagrama',
             open: 'Abrir',
-
             diagram_actions: {
                 open: 'Abrir',
                 duplicate: 'Duplicar',
                 delete: 'Eliminar',
             },
         },
-
         export_sql_dialog: {
             title: 'Exportar SQL',
             description:
@@ -351,7 +334,6 @@ export const es: LanguageTranslation = {
                     'Siéntete libre de usar tu OPENAI_TOKEN, consulta el manual <0>aquí</0>.',
             },
         },
-
         create_relationship_dialog: {
             cancel: 'Cancelar',
             create: 'Crear',
@@ -367,7 +349,6 @@ export const es: LanguageTranslation = {
             referenced_table_placeholder: 'Seleccionar tabla',
             title: 'Crear Relación',
         },
-
         import_database_dialog: {
             title: 'Importar a Diagrama Actual',
             override_alert: {
@@ -386,7 +367,6 @@ export const es: LanguageTranslation = {
                 cancel: 'Cancelar',
             },
         },
-
         export_image_dialog: {
             title: 'Exportar imagen',
             description: 'Escoge el factor de escalamiento para exportar:',
@@ -396,14 +376,13 @@ export const es: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'Cancelar',
             export: 'Exportar',
-            // TODO: Translate
-            advanced_options: 'Advanced Options',
-            pattern: 'Include background pattern',
-            pattern_description: 'Add subtle grid pattern to background.',
-            transparent: 'Transparent background',
-            transparent_description: 'Remove background color from image.',
+            advanced_options: 'Opciones avanzadas',
+            pattern: 'Incluir patrón de fondo',
+            pattern_description:
+                'Añade un patrón de cuadrícula sutil al fondo.',
+            transparent: 'Fondo transparente',
+            transparent_description: 'Elimina el color de fondo de la imagen.',
         },
-
         new_table_schema_dialog: {
             title: 'Seleccionar Esquema',
             description:
@@ -411,7 +390,6 @@ export const es: LanguageTranslation = {
             cancel: 'Cancelar',
             confirm: 'Confirmar',
         },
-
         update_table_schema_dialog: {
             title: 'Cambiar Esquema',
             description: 'Actualizar esquema de la tabla "{{tableName}}"',
@@ -425,7 +403,6 @@ export const es: LanguageTranslation = {
             create: 'Crear',
             cancel: 'Cancelar',
         },
-
         star_us_dialog: {
             title: '¡Ayúdanos a mejorar!',
             description:
@@ -433,44 +410,41 @@ export const es: LanguageTranslation = {
             close: 'Ahora no',
             confirm: '¡Claro!',
         },
-
-        // TODO: Translate
         export_diagram_dialog: {
-            title: 'Export Diagram',
-            description: 'Choose the format for export:',
+            title: 'Exportar diagrama',
+            description: 'Elija el formato para la exportación:',
             format_json: 'JSON',
-            cancel: 'Cancel',
-            export: 'Export',
+            cancel: 'Cancelar',
+            export: 'Exportar',
             error: {
-                title: 'Error exporting diagram',
+                title: 'Error al exportar el diagrama',
                 description:
-                    'Something went wrong. Need help? support@chartdb.io',
+                    'Se ha producido un error. ¿Necesitas ayuda? support@chartdb.io',
             },
         },
-        // TODO: Translate
         import_diagram_dialog: {
-            title: 'Import Diagram',
-            description: 'Paste the diagram JSON below:',
-            cancel: 'Cancel',
-            import: 'Import',
+            title: 'Importar diagrama',
+            description: 'Pega el JSON del diagrama a continuación:',
+            cancel: 'Cancelar',
+            import: 'Importar',
             error: {
-                title: 'Error importing diagram',
+                title: 'Error al importar el diagrama',
                 description:
-                    'The diagram JSON is invalid. Please check the JSON and try again. Need help? support@chartdb.io',
+                    'El JSON del diagrama no es válido. Compruebe el JSON e inténtelo de nuevo. ¿Necesitas ayuda? support@chartdb.io',
             },
         },
-        // TODO: Translate
         import_dbml_dialog: {
-            example_title: 'Import Example DBML',
-            title: 'Import DBML',
-            description: 'Import a database schema from DBML format.',
-            import: 'Import',
-            cancel: 'Cancel',
-            skip_and_empty: 'Skip & Empty',
-            show_example: 'Show Example',
+            example_title: 'Importar Ejemplo DBML',
+            title: 'Importar DBML',
+            description:
+                'Importar un esquema de base de datos desde el formato DBML.',
+            import: 'Importar',
+            cancel: 'Cancelar',
+            skip_and_empty: 'Saltar y vaciar',
+            show_example: 'Mostrar ejemplo',
             error: {
                 title: 'Error',
-                description: 'Failed to parse DBML. Please check the syntax.',
+                description: 'Error al analizar DBML. Comprueba la sintaxis.',
             },
         },
         relationship_type: {
@@ -479,33 +453,25 @@ export const es: LanguageTranslation = {
             many_to_one: 'Muchos a Uno',
             many_to_many: 'Muchos a Muchos',
         },
-
         canvas_context_menu: {
             new_table: 'Nueva Tabla',
             new_view: 'Nueva Vista',
             new_relationship: 'Nueva Relación',
-            // TODO: Translate
-            new_area: 'New Area',
+            new_area: 'Nueva Área',
         },
-
         table_node_context_menu: {
             edit_table: 'Editar Tabla',
-            duplicate_table: 'Duplicate Table', // TODO: Translate
+            duplicate_table: 'Duplicar Tabla',
             delete_table: 'Eliminar Tabla',
-            add_relationship: 'Add Relationship', // TODO: Translate
+            add_relationship: 'Agregar Relación',
         },
-
-        // TODO: Add translations
-        snap_to_grid_tooltip: 'Snap to Grid (Hold {{key}})',
-
+        snap_to_grid_tooltip: 'Ajustar a la cuadrícula (mantener {{key}})',
         tool_tips: {
             double_click_to_edit: 'Doble clic para editar',
         },
-
         language_select: {
             change_language: 'Idioma',
         },
-
         on: 'Encendido',
         off: 'Apagado',
     },

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -13,7 +13,7 @@ export const fr: LanguageTranslation = {
         },
         menu: {
             actions: {
-                actions: 'Actions',
+                actions: 'Actes',
                 new: 'Nouveau...',
                 browse: 'Parcourir...',
                 save: 'Enregistrer',
@@ -113,6 +113,12 @@ export const fr: LanguageTranslation = {
         copy_to_clipboard: 'Copier dans le presse-papiers',
         copied: 'Copié !',
 
+        share_table_dialog: {
+            title: 'Table de partage',
+            description: 'Copiez le lien ci-dessous pour partager ce tableau.',
+            close: 'Fermer',
+        },
+
         side_panel: {
             view_all_options: 'Voir toutes les Options...',
             tables_section: {
@@ -147,10 +153,8 @@ export const fr: LanguageTranslation = {
                         comments: 'Commentaires',
                         no_comments: 'Pas de commentaires',
                         delete_field: 'Supprimer le Champ',
-                        // TODO: Translate
                         default_value: 'Default Value',
                         no_default: 'No default',
-                        // TODO: Translate
                         character_length: 'Max Length',
                         precision: 'Précision',
                         scale: 'Échelle',
@@ -190,7 +194,7 @@ export const fr: LanguageTranslation = {
                     cardinality: 'Cardinalité',
                     delete_relationship: 'Supprimer',
                     relationship_actions: {
-                        title: 'Actions',
+                        title: 'Actes',
                         delete_relationship: 'Supprimer',
                     },
                 },
@@ -200,7 +204,7 @@ export const fr: LanguageTranslation = {
                     dependent_table: 'Vue Dépendante',
                     delete_dependency: 'Supprimer',
                     dependency_actions: {
-                        title: 'Actions',
+                        title: 'Actes',
                         delete_dependency: 'Supprimer',
                     },
                 },
@@ -209,55 +213,54 @@ export const fr: LanguageTranslation = {
                     description: 'Créez une relation pour commencer',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
+                areas: 'Zones',
+                add_area: 'Ajouter une zone',
+                filter: 'Filtre',
+                clear: 'Filtre effacer',
+                no_results: 'Aucune zone ne correspond à votre filtre.',
 
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: 'Actions de la région',
+                        edit_name: 'Modifier le nom',
+                        delete_area: 'Supprimer la zone',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: 'Pas de zones',
+                    description: 'Créer une zone pour commencer',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: 'Types personnalisés',
+                filter: 'Filtre',
+                clear: 'Filtre effacer',
+                no_results:
+                    'Aucun type personnalisé trouvé correspondant à votre filtre.',
                 empty_state: {
-                    title: 'No custom types',
+                    title: 'Pas de types personnalisés',
                     description:
-                        'Custom types will appear here when they are available in your database',
+                        "Les types personnalisés apparaîtront ici lorsqu'ils seront disponibles dans votre base de données",
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: 'Gentil',
+                    enum_values: "Valeurs d'énumération",
+                    composite_fields: 'Champs',
+                    no_fields: 'Aucun champ défini',
                     no_values: "Aucune valeur d'énumération définie",
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: 'Nom de champ',
+                    field_type_placeholder: 'Sélectionner le type',
+                    add_field: 'Ajouter un champ',
+                    no_fields_tooltip:
+                        'Aucun champ défini pour ce type personnalisé',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: 'Actes',
+                        highlight_fields: 'Mettre en surbrillance les champs',
+                        delete_custom_type: 'Supprimer',
+                        clear_field_highlight: 'Point culminant clair',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: 'Supprimer le type',
                 },
             },
         },
@@ -275,7 +278,6 @@ export const fr: LanguageTranslation = {
             custom_type_highlight_tooltip:
                 'Highlighting "{{typeName}}" - Click to clear',
             highlight_overlapping_tables: 'Surligner les tables chevauchées',
-            // TODO: Translate
             filter: 'Filter Tables',
         },
 
@@ -323,6 +325,7 @@ export const fr: LanguageTranslation = {
                 tables_count: 'Tables',
             },
             cancel: 'Annuler',
+            start_new: 'Commencer avec un nouveau diagramme',
             open: 'Ouvrir',
 
             diagram_actions: {
@@ -359,7 +362,6 @@ export const fr: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'Annuler',
             export: 'Exporter',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -480,7 +482,6 @@ export const fr: LanguageTranslation = {
             new_table: 'Nouvelle Table',
             new_view: 'Nouvelle Vue',
             new_relationship: 'Nouvelle Relation',
-            // TODO: Translate
             new_area: 'New Area',
         },
 

--- a/src/i18n/locales/gu.ts
+++ b/src/i18n/locales/gu.ts
@@ -41,9 +41,8 @@ export const gu: LanguageTranslation = {
                 theme: 'થિમ',
                 show_dependencies: 'નિર્ભરતાઓ બતાવો',
                 hide_dependencies: 'નિર્ભરતાઓ છુપાવો',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'મિની નકશો બતાવો',
+                hide_minimap: 'મિની નકશો છુપાવો',
             },
 
             backup: {
@@ -115,6 +114,12 @@ export const gu: LanguageTranslation = {
         copy_to_clipboard: 'ક્લિપબોર્ડમાં નકલ કરો',
         copied: 'નકલ થયું!',
 
+        share_table_dialog: {
+            title: 'શેર ટેબલ',
+            description: 'આ કોષ્ટકને શેર કરવા માટે નીચેની લિંકની નકલ કરો.',
+            close: 'બંધ',
+        },
+
         side_panel: {
             view_all_options: 'બધા વિકલ્પો જુઓ...',
             tables_section: {
@@ -123,17 +128,15 @@ export const gu: LanguageTranslation = {
                 add_view: 'વ્યૂ ઉમેરો',
                 filter: 'ફિલ્ટર',
                 collapse: 'બધાને સકુચિત કરો',
-                // TODO: Translate
-                clear: 'Clear Filter',
-                no_results: 'No tables found matching your filter.',
-                // TODO: Translate
-                show_list: 'Show Table List',
-                show_dbml: 'Show DBML Editor',
+                clear: 'સ્પષ્ટ ગણાવી',
+                no_results:
+                    'કોઈ કોષ્ટકો તમારા ફિલ્ટર સાથે મેળ ખાતા મળ્યાં નથી.',
+                show_list: 'કોષ્ટક સૂચિ બતાવો',
+                show_dbml: 'ડીબીએમએલ સંપાદક બતાવો',
 
                 table: {
                     fields: 'ફીલ્ડ્સ',
-                    //TODO translate
-                    nullable: 'Nullable?',
+                    nullable: 'ન્યુલેબલ?',
                     primary_key: 'પ્રાથમિક કી',
                     indexes: 'ઈન્ડેક્સ',
                     comments: 'ટિપ્પણીઓ',
@@ -151,10 +154,8 @@ export const gu: LanguageTranslation = {
                         comments: 'ટિપ્પણીઓ',
                         no_comments: 'કોઈ ટિપ્પણીઓ નથી',
                         delete_field: 'ફીલ્ડ કાઢી નાખો',
-                        // TODO: Translate
                         default_value: 'Default Value',
                         no_default: 'No default',
-                        // TODO: Translate
                         character_length: 'Max Length',
                         precision: 'ચોકસાઈ',
                         scale: 'માપ',
@@ -213,55 +214,55 @@ export const gu: LanguageTranslation = {
                     description: 'શરૂ કરવા માટે એક સંબંધ બનાવો',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
+                areas: 'વિસ્તારો',
+                add_area: 'ઉમેરો',
+                filter: 'ફિલ્ટર કરવું',
+                clear: 'સ્પષ્ટ ગણાવી',
+                no_results:
+                    'કોઈ ક્ષેત્ર તમારા ફિલ્ટર સાથે મેળ ખાતા મળ્યાં નથી.',
 
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: 'વિસ્તાર ક્રિયાઓ',
+                        edit_name: 'નામ સંપાદિત કરો',
+                        delete_area: 'વિસ્તાર કા delો',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: 'કોઈ ક્ષેત્ર',
+                    description: 'પ્રારંભ કરવા માટે એક ક્ષેત્ર બનાવો',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: 'રિવાજ પ્રકારો',
+                filter: 'ફિલ્ટર કરવું',
+                clear: 'સ્પષ્ટ ગણાવી',
+                no_results:
+                    'તમારા ફિલ્ટર સાથે મેળ ખાતા કોઈ કસ્ટમ પ્રકારો મળ્યાં નથી.',
                 empty_state: {
-                    title: 'No custom types',
+                    title: 'કોઈ કસ્ટમ પ્રકારો નથી',
                     description:
-                        'Custom types will appear here when they are available in your database',
+                        'જ્યારે તમારા ડેટાબેઝમાં ઉપલબ્ધ હોય ત્યારે કસ્ટમ પ્રકારો અહીં દેખાશે',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: 'પ્રકાર',
+                    enum_values: 'Enન',
+                    composite_fields: 'ખેતરો',
+                    no_fields: 'કોઈ ક્ષેત્ર વ્યાખ્યાયિત નથી',
                     no_values: 'કોઈ enum મૂલ્યો વ્યાખ્યાયિત નથી',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: 'ક્ષેત્રનું નામ',
+                    field_type_placeholder: 'પ્રકાર પસંદ કરો',
+                    add_field: 'ક્ષેત્ર ઉમેરો',
+                    no_fields_tooltip:
+                        'આ કસ્ટમ પ્રકાર માટે કોઈ ક્ષેત્ર નિર્ધારિત નથી',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: 'ક્રિયા',
+                        highlight_fields: 'પ્રકાશિત ક્ષેત્ર',
+                        delete_custom_type: 'કા delી નાખવું',
+                        clear_field_highlight: 'સ્પષ્ટ વિશેષતા',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: 'પ્રકાર કા Delete ી નાખો',
                 },
             },
         },
@@ -279,7 +280,6 @@ export const gu: LanguageTranslation = {
             custom_type_highlight_tooltip:
                 'Highlighting "{{typeName}}" - Click to clear',
             highlight_overlapping_tables: 'ઓવરલેપ કરતો ટેબલ હાઇલાઇટ કરો',
-            // TODO: Translate
             filter: 'Filter Tables',
         },
 
@@ -325,6 +325,7 @@ export const gu: LanguageTranslation = {
                 tables_count: 'ટેબલ્સ',
             },
             cancel: 'રદ કરો',
+            start_new: 'નવા આલેખ સાથે પ્રારંભ કરો',
             open: 'ખોલો',
 
             diagram_actions: {
@@ -395,7 +396,6 @@ export const gu: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'રદ કરો',
             export: 'નિકાસ કરો',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -458,7 +458,6 @@ export const gu: LanguageTranslation = {
                     'ડાયાગ્રામ JSON અમાન્ય છે. કૃપા કરીને JSON તપાસો અને ફરી પ્રયાસ કરો. મદદ જોઈએ? support@chartdb.io પર સંપર્ક કરો.',
             },
         },
-        // TODO: Translate
         import_dbml_dialog: {
             example_title: 'Import Example DBML',
             title: 'Import DBML',
@@ -483,7 +482,6 @@ export const gu: LanguageTranslation = {
             new_table: 'નવું ટેબલ',
             new_view: 'નવું વ્યૂ',
             new_relationship: 'નવો સંબંધ',
-            // TODO: Translate
             new_area: 'New Area',
         },
 
@@ -491,7 +489,7 @@ export const gu: LanguageTranslation = {
             edit_table: 'ટેબલ સંપાદિત કરો',
             duplicate_table: 'ટેબલ નકલ કરો',
             delete_table: 'ટેબલ કાઢી નાખો',
-            add_relationship: 'Add Relationship', // TODO: Translate
+            add_relationship: 'સંબંધ ઉમેરો',
         },
 
         snap_to_grid_tooltip: 'ગ્રિડ પર સ્નેપ કરો (જમાવટ {{key}})',

--- a/src/i18n/locales/hi.ts
+++ b/src/i18n/locales/hi.ts
@@ -41,9 +41,8 @@ export const hi: LanguageTranslation = {
                 theme: 'थीम',
                 show_dependencies: 'निर्भरता दिखाएँ',
                 hide_dependencies: 'निर्भरता छिपाएँ',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'मिनी मानचित्र दिखाएं',
+                hide_minimap: 'मिनी मानचित्र छिपाएं',
             },
             backup: {
                 backup: 'बैकअप',
@@ -111,9 +110,15 @@ export const hi: LanguageTranslation = {
         clear: 'साफ़ करें',
         show_more: 'अधिक दिखाएँ',
         show_less: 'कम दिखाएँ',
-        // TODO: Translate
         copy_to_clipboard: 'Copy to Clipboard',
         copied: 'Copied!',
+
+        share_table_dialog: {
+            title: 'शेयर सारणी',
+            description:
+                'इस तालिका को साझा करने के लिए नीचे दिए गए लिंक को कॉपी करें।',
+            close: 'बंद करना',
+        },
 
         side_panel: {
             view_all_options: 'सभी विकल्प देखें...',
@@ -123,12 +128,10 @@ export const hi: LanguageTranslation = {
                 add_view: 'व्यू जोड़ें',
                 filter: 'फ़िल्टर',
                 collapse: 'सभी को संक्षिप्त करें',
-                // TODO: Translate
-                clear: 'Clear Filter',
-                no_results: 'No tables found matching your filter.',
-                // TODO: Translate
-                show_list: 'Show Table List',
-                show_dbml: 'Show DBML Editor',
+                clear: 'स्पष्ट फ़िल्टर',
+                no_results: 'कोई भी टेबल आपके फ़िल्टर से मेल नहीं पाया।',
+                show_list: 'तालिका सूची दिखाएं',
+                show_dbml: 'DBML संपादक दिखाएं',
 
                 table: {
                     fields: 'फ़ील्ड्स',
@@ -150,10 +153,8 @@ export const hi: LanguageTranslation = {
                         comments: 'टिप्पणियाँ',
                         no_comments: 'कोई टिप्पणी नहीं',
                         delete_field: 'फ़ील्ड हटाएँ',
-                        // TODO: Translate
                         default_value: 'Default Value',
                         no_default: 'No default',
-                        // TODO: Translate
                         character_length: 'Max Length',
                         precision: 'Precision',
                         scale: 'Scale',
@@ -170,7 +171,7 @@ export const hi: LanguageTranslation = {
                         change_schema: 'स्कीमा बदलें',
                         add_field: 'फ़ील्ड जोड़ें',
                         add_index: 'सूचकांक जोड़ें',
-                        duplicate_table: 'Duplicate Table', // TODO: Translate
+                        duplicate_table: 'डुप्लिकेट टेबल',
                         delete_table: 'तालिका हटाएँ',
                     },
                 },
@@ -212,55 +213,53 @@ export const hi: LanguageTranslation = {
                     description: 'शुरू करने के लिए एक संबंध बनाएँ',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
+                areas: 'क्षेत्रों',
+                add_area: 'क्षेत्र जोड़ें',
+                filter: 'फ़िल्टर',
+                clear: 'स्पष्ट फ़िल्टर',
+                no_results: 'कोई भी क्षेत्र आपके फ़िल्टर से मेल नहीं खाता।',
 
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: 'क्षेत्र कार्य',
+                        edit_name: 'नाम संपादित करें',
+                        delete_area: 'क्षेत्र हटाएं',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: 'कोई क्षेत्र नहीं',
+                    description: 'आरंभ करने के लिए एक क्षेत्र बनाएं',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: 'कस्टम प्रकार',
+                filter: 'फ़िल्टर',
+                clear: 'स्पष्ट फ़िल्टर',
+                no_results: 'कोई कस्टम प्रकार आपके फ़िल्टर से मेल नहीं खाता।',
                 empty_state: {
-                    title: 'No custom types',
+                    title: 'कोई कस्टम प्रकार नहीं',
                     description:
-                        'Custom types will appear here when they are available in your database',
+                        'कस्टम प्रकार यहां दिखाई देंगे जब वे आपके डेटाबेस में उपलब्ध होंगे',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: 'दयालु',
+                    enum_values: 'मूल मान',
+                    composite_fields: 'फील्ड्स',
+                    no_fields: 'कोई फ़ील्ड परिभाषित नहीं',
                     no_values: 'कोई enum मान परिभाषित नहीं',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: 'क्षेत्र नाम',
+                    field_type_placeholder: 'प्रकार का चयन करें',
+                    add_field: 'क्षेत्र जोड़ें',
+                    no_fields_tooltip:
+                        'इस कस्टम प्रकार के लिए कोई फ़ील्ड परिभाषित नहीं है',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: 'कार्रवाई',
+                        highlight_fields: 'फील्ड हाइलाइट करें',
+                        delete_custom_type: 'मिटाना',
+                        clear_field_highlight: 'स्पष्ट मुख्य आकर्षण',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: 'हटाएं प्रकार',
                 },
             },
         },
@@ -278,7 +277,6 @@ export const hi: LanguageTranslation = {
             custom_type_highlight_tooltip:
                 'Highlighting "{{typeName}}" - Click to clear',
             highlight_overlapping_tables: 'ओवरलैपिंग तालिकाओं को हाइलाइट करें',
-            // TODO: Translate
             filter: 'Filter Tables',
         },
 
@@ -304,13 +302,11 @@ export const hi: LanguageTranslation = {
                     step_2: 'यदि आप "ग्रिड में परिणाम" का उपयोग कर रहे हैं, तो Non-XML डेटा के लिए अधिकतम वर्ण प्राप्ति (9999999 पर सेट करें)।',
                 },
                 instructions_link: 'मदद चाहिए? देखें कैसे',
-                // TODO: Translate
                 check_script_result: 'Check Script Result',
             },
 
             cancel: 'रद्द करें',
             back: 'वापस',
-            // TODO: Translate
             import_from_file: 'Import from File',
             empty_diagram: 'खाली आरेख',
             continue: 'जारी रखें',
@@ -327,6 +323,7 @@ export const hi: LanguageTranslation = {
                 tables_count: 'तालिकाएँ',
             },
             cancel: 'रद्द करें',
+            start_new: 'एक नए आरेख से शुरू करें',
             open: 'खोलें',
 
             diagram_actions: {
@@ -397,7 +394,6 @@ export const hi: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'रद्द करें',
             export: 'निर्यात करें',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -435,7 +431,6 @@ export const hi: LanguageTranslation = {
             close: 'अभी नहीं',
             confirm: 'बिलकुल!',
         },
-        // TODO: Translate
         export_diagram_dialog: {
             title: 'Export Diagram',
             description: 'Choose the format for export:',
@@ -448,19 +443,16 @@ export const hi: LanguageTranslation = {
                     'Something went wrong. Need help? support@chartdb.io',
             },
         },
-        // TODO: Translate
         import_diagram_dialog: {
-            title: 'Import Diagram',
+            title: 'आयात आरेख',
             description: 'Paste the diagram JSON below:',
             cancel: 'Cancel',
             import: 'Import',
             error: {
-                title: 'Error importing diagram',
-                description:
-                    'The diagram JSON is invalid. Please check the JSON and try again. Need help? support@chartdb.io',
+                title: 'त्रुटि आयात आरेख',
+                description: 'आरेख JSON अमान्य है। ',
             },
         },
-        // TODO: Translate
         import_dbml_dialog: {
             example_title: 'Import Example DBML',
             title: 'Import DBML',
@@ -485,18 +477,15 @@ export const hi: LanguageTranslation = {
             new_table: 'नई तालिका',
             new_view: 'नया व्यू',
             new_relationship: 'नया संबंध',
-            // TODO: Translate
             new_area: 'New Area',
         },
 
         table_node_context_menu: {
             edit_table: 'तालिका संपादित करें',
-            duplicate_table: 'Duplicate Table', // TODO: Translate
+            duplicate_table: 'डुप्लिकेट टेबल',
             delete_table: 'तालिका हटाएँ',
-            add_relationship: 'Add Relationship', // TODO: Translate
+            add_relationship: 'संबंध जोड़ें',
         },
-
-        // TODO: Add translations
         snap_to_grid_tooltip: 'Snap to Grid (Hold {{key}})',
 
         tool_tips: {

--- a/src/i18n/locales/hr.ts
+++ b/src/i18n/locales/hr.ts
@@ -113,6 +113,13 @@ export const hr: LanguageTranslation = {
         copy_to_clipboard: 'Kopiraj u međuspremnik',
         copied: 'Kopirano!',
 
+        share_table_dialog: {
+            title: 'Dijeljenje stola',
+            description:
+                'Kopirajte donju vezu da biste podijelili ovu tablicu.',
+            close: 'Zatvoriti',
+        },
+
         side_panel: {
             view_all_options: 'Prikaži sve opcije...',
             tables_section: {
@@ -320,6 +327,7 @@ export const hr: LanguageTranslation = {
                 tables_count: 'Tablice',
             },
             cancel: 'Odustani',
+            start_new: 'Započni s novim dijagramom',
             open: 'Otvori',
 
             diagram_actions: {

--- a/src/i18n/locales/id_ID.ts
+++ b/src/i18n/locales/id_ID.ts
@@ -41,9 +41,8 @@ export const id_ID: LanguageTranslation = {
                 theme: 'Tema',
                 show_dependencies: 'Tampilkan Dependensi',
                 hide_dependencies: 'Sembunyikan Dependensi',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'Tampilkan Peta Mini',
+                hide_minimap: 'Sembunyikan Peta Mini',
             },
             backup: {
                 backup: 'Cadangan',
@@ -114,6 +113,13 @@ export const id_ID: LanguageTranslation = {
         copy_to_clipboard: 'Salin ke Clipboard',
         copied: 'Tersalin!',
 
+        share_table_dialog: {
+            title: 'Tabel berbagi',
+            description:
+                'Salin tautan di bawah ini untuk membagikan tabel ini.',
+            close: 'Menutup',
+        },
+
         side_panel: {
             view_all_options: 'Tampilkan Semua Pilihan...',
             tables_section: {
@@ -122,12 +128,11 @@ export const id_ID: LanguageTranslation = {
                 add_view: 'Tambah Tampilan',
                 filter: 'Saring',
                 collapse: 'Lipat Semua',
-                // TODO: Translate
-                clear: 'Clear Filter',
-                no_results: 'No tables found matching your filter.',
-                // TODO: Translate
-                show_list: 'Show Table List',
-                show_dbml: 'Show DBML Editor',
+                clear: 'CLEAR FILTER',
+                no_results:
+                    'Tidak ada tabel yang ditemukan cocok dengan filter Anda.',
+                show_list: 'Tampilkan daftar tabel',
+                show_dbml: 'Tampilkan editor DBML',
 
                 table: {
                     fields: 'Kolom',
@@ -149,10 +154,8 @@ export const id_ID: LanguageTranslation = {
                         comments: 'Komentar',
                         no_comments: 'Tidak ada komentar',
                         delete_field: 'Hapus Kolom',
-                        // TODO: Translate
                         default_value: 'Default Value',
                         no_default: 'No default',
-                        // TODO: Translate
                         character_length: 'Max Length',
                         precision: 'Presisi',
                         scale: 'Skala',
@@ -211,55 +214,55 @@ export const id_ID: LanguageTranslation = {
                     description: 'Buat hubungan untuk memulai',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
+                areas: 'Area',
+                add_area: 'Tambahkan area',
+                filter: 'Menyaring',
+                clear: 'CLEAR FILTER',
+                no_results:
+                    'Tidak ada area yang ditemukan cocok dengan filter Anda.',
 
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: 'Tindakan Area',
+                        edit_name: 'Edit nama',
+                        delete_area: 'Hapus area',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: 'Tidak ada area',
+                    description: 'Buat area untuk memulai',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: 'Jenis Kustom',
+                filter: 'Menyaring',
+                clear: 'CLEAR FILTER',
+                no_results:
+                    'Tidak ada tipe khusus yang ditemukan sesuai dengan filter Anda.',
                 empty_state: {
-                    title: 'No custom types',
+                    title: 'Tidak ada tipe khusus',
                     description:
-                        'Custom types will appear here when they are available in your database',
+                        'Jenis kustom akan muncul di sini saat tersedia di database Anda',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: 'Baik',
+                    enum_values: 'Nilai enum',
+                    composite_fields: 'Bidang',
+                    no_fields: 'Tidak ada bidang yang ditentukan',
                     no_values: 'Tidak ada nilai enum yang ditentukan',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: 'Nama Lapangan',
+                    field_type_placeholder: 'Pilih Jenis',
+                    add_field: 'Tambahkan bidang',
+                    no_fields_tooltip:
+                        'Tidak ada bidang yang ditentukan untuk jenis khusus ini',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: 'Tindakan',
+                        highlight_fields: 'Sorotan bidang',
+                        delete_custom_type: 'Menghapus',
+                        clear_field_highlight: 'Sorotan yang jelas',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: 'Jenis Hapus',
                 },
             },
         },
@@ -277,7 +280,6 @@ export const id_ID: LanguageTranslation = {
             custom_type_highlight_tooltip:
                 'Highlighting "{{typeName}}" - Click to clear',
             highlight_overlapping_tables: 'Sorot Tabel yang Tumpang Tindih',
-            // TODO: Translate
             filter: 'Filter Tables',
         },
 
@@ -324,6 +326,7 @@ export const id_ID: LanguageTranslation = {
                 tables_count: 'Tabel',
             },
             cancel: 'Batal',
+            start_new: 'Mulai dengan diagram baru',
             open: 'Buka',
 
             diagram_actions: {
@@ -393,7 +396,6 @@ export const id_ID: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'Batal',
             export: 'Ekspor',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -456,7 +458,6 @@ export const id_ID: LanguageTranslation = {
                     'Diagram JSON tidak valid. Silakan cek JSON dan coba lagi. Butuh bantuan? support@chartdb.io',
             },
         },
-        // TODO: Translate
         import_dbml_dialog: {
             example_title: 'Import Example DBML',
             title: 'Import DBML',
@@ -482,7 +483,6 @@ export const id_ID: LanguageTranslation = {
             new_table: 'Tabel Baru',
             new_view: 'Tampilan Baru',
             new_relationship: 'Hubungan Baru',
-            // TODO: Translate
             new_area: 'New Area',
         },
 
@@ -490,7 +490,7 @@ export const id_ID: LanguageTranslation = {
             edit_table: 'Ubah Tabel',
             delete_table: 'Hapus Tabel',
             duplicate_table: 'Duplikat Tabel',
-            add_relationship: 'Add Relationship', // TODO: Translate
+            add_relationship: 'Tambahkan hubungan',
         },
 
         snap_to_grid_tooltip: 'Snap ke Kisi (Tahan {{key}})',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -39,14 +39,11 @@ export const ja: LanguageTranslation = {
                 zoom_on_scroll: 'スクロールでズーム',
                 show_views: 'データベースビュー',
                 theme: 'テーマ',
-                // TODO: Translate
                 show_dependencies: 'Show Dependencies',
                 hide_dependencies: 'Hide Dependencies',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'ミニマップを表示',
+                hide_minimap: 'ミニマップを非表示',
             },
-            // TODO: Translate
             backup: {
                 backup: 'Backup',
                 export_diagram: 'Export Diagram',
@@ -114,9 +111,14 @@ export const ja: LanguageTranslation = {
         clear: 'クリア',
         show_more: 'さらに表示',
         show_less: '表示を減らす',
-        // TODO: Translate
         copy_to_clipboard: 'Copy to Clipboard',
         copied: 'Copied!',
+
+        share_table_dialog: {
+            title: 'テーブルを共有します',
+            description: '以下のリンクをコピーして、このテーブルを共有します。',
+            close: '近い',
+        },
 
         side_panel: {
             view_all_options: 'すべてのオプションを表示...',
@@ -126,12 +128,11 @@ export const ja: LanguageTranslation = {
                 add_view: 'ビューを追加',
                 filter: 'フィルタ',
                 collapse: 'すべて折りたたむ',
-                // TODO: Translate
-                clear: 'Clear Filter',
-                no_results: 'No tables found matching your filter.',
-                // TODO: Translate
-                show_list: 'Show Table List',
-                show_dbml: 'Show DBML Editor',
+                clear: 'クリアフィルター',
+                no_results:
+                    'フィルターに一致するテーブルは見つかりませんでした。',
+                show_list: 'テーブルリストを表示します',
+                show_dbml: 'DBMLエディターを表示します',
 
                 table: {
                     fields: 'フィールド',
@@ -153,10 +154,8 @@ export const ja: LanguageTranslation = {
                         comments: 'コメント',
                         no_comments: 'コメントがありません',
                         delete_field: 'フィールドを削除',
-                        // TODO: Translate
                         default_value: 'Default Value',
                         no_default: 'No default',
-                        // TODO: Translate
                         character_length: 'Max Length',
                         precision: '精度',
                         scale: '小数点以下桁数',
@@ -173,7 +172,7 @@ export const ja: LanguageTranslation = {
                         change_schema: 'スキーマを変更',
                         add_field: 'フィールドを追加',
                         add_index: 'インデックスを追加',
-                        duplicate_table: 'Duplicate Table', // TODO: Translate
+                        duplicate_table: '複製テーブル',
                         delete_table: 'テーブルを削除',
                     },
                 },
@@ -216,55 +215,54 @@ export const ja: LanguageTranslation = {
                         '開始するためにリレーションシップを作成してください',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
+                areas: 'エリア',
+                add_area: 'エリアを追加します',
+                filter: 'フィルター',
+                clear: 'クリアフィルター',
+                no_results: 'フィルターに一致する領域は見つかりませんでした。',
 
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: 'エリアアクション',
+                        edit_name: '名前を編集します',
+                        delete_area: 'エリアを削除します',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: 'エリアはありません',
+                    description: '開始するエリアを作成します',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: 'カスタムタイプ',
+                filter: 'フィルター',
+                clear: 'クリアフィルター',
+                no_results:
+                    'フィルターに一致するカスタムタイプは見つかりませんでした。',
                 empty_state: {
-                    title: 'No custom types',
+                    title: 'カスタムタイプはありません',
                     description:
-                        'Custom types will appear here when they are available in your database',
+                        'カスタムタイプは、データベースで使用できるときにここに表示されます',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: '親切',
+                    enum_values: '列挙値',
+                    composite_fields: 'フィールド',
+                    no_fields: '定義されたフィールドはありません',
                     no_values: '列挙値が定義されていません',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: 'フィールド名',
+                    field_type_placeholder: '[タイプ]を選択します',
+                    add_field: 'フィールドを追加します',
+                    no_fields_tooltip:
+                        'このカスタムタイプのフィールドは定義されていません',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: 'アクション',
+                        highlight_fields: 'フィールドを強調表示します',
+                        delete_custom_type: '消去',
+                        clear_field_highlight: 'クリアハイライト',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: 'タイプを削除します',
                 },
             },
         },
@@ -281,7 +279,7 @@ export const ja: LanguageTranslation = {
             highlight_overlapping_tables: 'Highlight Overlapping Tables',
             clear_custom_type_highlight: 'Clear highlight for "{{typeName}}"',
             custom_type_highlight_tooltip:
-                'Highlighting "{{typeName}}" - Click to clear', // TODO: Translate
+                'Highlighting "{{typeName}}" - Click to clear',
             filter: 'Filter Tables',
         },
 
@@ -305,14 +303,12 @@ export const ja: LanguageTranslation = {
                     step_1: 'ツール > オプション > クエリ結果 > SQL Serverに移動します。',
                     step_2: '「グリッドへの結果」を使用している場合、XML以外のデータの最大取得文字数を変更してください（9999999に設定）。',
                 },
-                // TODO: Translate
                 instructions_link: 'Need help? Watch how',
                 check_script_result: 'Check Script Result',
             },
 
             cancel: 'キャンセル',
             back: '戻る',
-            // TODO: Translate
             import_from_file: 'Import from File',
             empty_diagram: '空のダイアグラム',
             continue: '続行',
@@ -329,6 +325,7 @@ export const ja: LanguageTranslation = {
                 tables_count: 'テーブル数',
             },
             cancel: 'キャンセル',
+            start_new: '新しいダイアグラムで開始',
             open: '開く',
 
             diagram_actions: {
@@ -399,7 +396,6 @@ export const ja: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'キャンセル',
             export: 'エクスポート',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -437,7 +433,6 @@ export const ja: LanguageTranslation = {
             close: '今はしない',
             confirm: 'もちろん！',
         },
-        // TODO: Translate
         export_diagram_dialog: {
             title: 'Export Diagram',
             description: 'Choose the format for export:',
@@ -450,19 +445,16 @@ export const ja: LanguageTranslation = {
                     'Something went wrong. Need help? support@chartdb.io',
             },
         },
-        // TODO: Translate
         import_diagram_dialog: {
-            title: 'Import Diagram',
+            title: 'インポート図',
             description: 'Paste the diagram JSON below:',
             cancel: 'Cancel',
             import: 'Import',
             error: {
-                title: 'Error importing diagram',
-                description:
-                    'The diagram JSON is invalid. Please check the JSON and try again. Need help? support@chartdb.io',
+                title: '図のインポートエラー',
+                description: '図JSONは無効です。 ',
             },
         },
-        // TODO: Translate
         import_dbml_dialog: {
             example_title: 'Import Example DBML',
             title: 'Import DBML',
@@ -487,18 +479,15 @@ export const ja: LanguageTranslation = {
             new_table: '新しいテーブル',
             new_view: '新しいビュー',
             new_relationship: '新しいリレーションシップ',
-            // TODO: Translate
             new_area: 'New Area',
         },
 
         table_node_context_menu: {
             edit_table: 'テーブルを編集',
-            duplicate_table: 'Duplicate Table', // TODO: Translate
+            duplicate_table: '複製テーブル',
             delete_table: 'テーブルを削除',
-            add_relationship: 'Add Relationship', // TODO: Translate
+            add_relationship: '関係を追加します',
         },
-
-        // TODO: Add translations
         snap_to_grid_tooltip: 'Snap to Grid (Hold {{key}})',
 
         tool_tips: {

--- a/src/i18n/locales/ko_KR.ts
+++ b/src/i18n/locales/ko_KR.ts
@@ -41,9 +41,8 @@ export const ko_KR: LanguageTranslation = {
                 theme: '테마',
                 show_dependencies: '종속성 보이기',
                 hide_dependencies: '종속성 숨기기',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: '미니 맵 표시',
+                hide_minimap: '미니 맵 숨기기',
             },
             backup: {
                 backup: '백업',
@@ -114,6 +113,12 @@ export const ko_KR: LanguageTranslation = {
         copy_to_clipboard: '클립보드에 복사',
         copied: '복사됨!',
 
+        share_table_dialog: {
+            title: '공유 테이블',
+            description: '이 표를 공유하려면 아래 링크를 복사하십시오.',
+            close: '닫다',
+        },
+
         side_panel: {
             view_all_options: '전체 옵션 보기...',
             tables_section: {
@@ -122,12 +127,10 @@ export const ko_KR: LanguageTranslation = {
                 add_view: '뷰 추가',
                 filter: '필터',
                 collapse: '모두 접기',
-                // TODO: Translate
-                clear: 'Clear Filter',
-                no_results: 'No tables found matching your filter.',
-                // TODO: Translate
-                show_list: 'Show Table List',
-                show_dbml: 'Show DBML Editor',
+                clear: '클리어 필터',
+                no_results: '필터와 일치하는 테이블이 없습니다.',
+                show_list: '표시 테이블 목록',
+                show_dbml: 'DBML 편집기를 보여줍니다',
 
                 table: {
                     fields: '필드',
@@ -149,10 +152,8 @@ export const ko_KR: LanguageTranslation = {
                         comments: '주석',
                         no_comments: '주석 없음',
                         delete_field: '필드 삭제',
-                        // TODO: Translate
                         default_value: 'Default Value',
                         no_default: 'No default',
-                        // TODO: Translate
                         character_length: 'Max Length',
                         precision: '정밀도',
                         scale: '소수점 자릿수',
@@ -211,55 +212,53 @@ export const ko_KR: LanguageTranslation = {
                     description: '연관 관계를 만들어 시작하세요.',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
+                areas: '지역',
+                add_area: '영역을 추가하십시오',
+                filter: '필터',
+                clear: '클리어 필터',
+                no_results: '필터와 일치하는 영역이 없습니다.',
 
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: '지역 행동',
+                        edit_name: '이름 편집',
+                        delete_area: '영역 삭제',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: '영역이 없습니다',
+                    description: '시작할 영역을 만듭니다',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: '사용자 정의 유형',
+                filter: '필터',
+                clear: '클리어 필터',
+                no_results: '필터와 일치하는 사용자 지정 유형이 없습니다.',
                 empty_state: {
-                    title: 'No custom types',
+                    title: '사용자 정의 유형이 없습니다',
                     description:
-                        'Custom types will appear here when they are available in your database',
+                        '데이터베이스에서 사용할 수있는 경우 사용자 정의 유형이 여기에 나타납니다.',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: '친절한',
+                    enum_values: '열거적인 값',
+                    composite_fields: '전지',
+                    no_fields: '정의 된 필드가 없습니다',
                     no_values: '정의된 열거형 값이 없습니다',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: '필드 이름',
+                    field_type_placeholder: '유형을 선택하십시오',
+                    add_field: '필드를 추가하십시오',
+                    no_fields_tooltip:
+                        '이 사용자 정의 유형에 대해 정의 된 필드는 없습니다',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: '행위',
+                        highlight_fields: '하이라이트 필드',
+                        delete_custom_type: '삭제',
+                        clear_field_highlight: '명확한 하이라이트',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: '삭제 유형',
                 },
             },
         },
@@ -277,7 +276,6 @@ export const ko_KR: LanguageTranslation = {
             custom_type_highlight_tooltip:
                 'Highlighting "{{typeName}}" - Click to clear',
             highlight_overlapping_tables: '겹치는 테이블 강조 표시',
-            // TODO: Translate
             filter: 'Filter Tables',
         },
 
@@ -324,6 +322,7 @@ export const ko_KR: LanguageTranslation = {
                 tables_count: '테이블 갯수',
             },
             cancel: '취소',
+            start_new: '새 다이어그램으로 시작',
             open: '열기',
 
             diagram_actions: {
@@ -393,7 +392,6 @@ export const ko_KR: LanguageTranslation = {
             scale_4x: '4x',
             cancel: '취소',
             export: '내보내기',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -454,7 +452,6 @@ export const ko_KR: LanguageTranslation = {
                     '다이어그램 JSON이 유효하지 않습니다. JSON이 올바른 형식인지 확인해주세요. 도움이 필요하신 경우 support@chartdb.io으로 연락해주세요.',
             },
         },
-        // TODO: Translate
         import_dbml_dialog: {
             example_title: 'Import Example DBML',
             title: 'Import DBML',
@@ -479,7 +476,6 @@ export const ko_KR: LanguageTranslation = {
             new_table: '새 테이블',
             new_view: '새 뷰',
             new_relationship: '새 연관관계',
-            // TODO: Translate
             new_area: 'New Area',
         },
 
@@ -487,7 +483,7 @@ export const ko_KR: LanguageTranslation = {
             edit_table: '테이블 수정',
             duplicate_table: '테이블 복제',
             delete_table: '테이블 삭제',
-            add_relationship: 'Add Relationship', // TODO: Translate
+            add_relationship: '관계를 추가하십시오',
         },
 
         snap_to_grid_tooltip: '그리드에 맞추기 ({{key}}를 누른채 유지)',

--- a/src/i18n/locales/mr.ts
+++ b/src/i18n/locales/mr.ts
@@ -41,12 +41,10 @@ export const mr: LanguageTranslation = {
                 theme: 'थीम',
                 show_dependencies: 'डिपेंडेन्सि दाखवा',
                 hide_dependencies: 'डिपेंडेन्सि लपवा',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'मिनी नकाशा दाखवा',
+                hide_minimap: 'मिनी नकाशा लपवा',
             },
             backup: {
-                // TODO: Add translations
                 backup: 'Backup',
                 export_diagram: 'Export Diagram',
                 restore_diagram: 'Restore Diagram',
@@ -112,10 +110,14 @@ export const mr: LanguageTranslation = {
         clear: 'साफ करा',
         show_more: 'अधिक दाखवा',
         show_less: 'कमी दाखवा',
-        // TODO: Add translations
         copy_to_clipboard: 'Copy to Clipboard',
-        // TODO: Add translations
         copied: 'Copied!',
+
+        share_table_dialog: {
+            title: 'सामायिक सारणी',
+            description: 'हे सारणी सामायिक करण्यासाठी खालील दुवा कॉपी करा.',
+            close: 'बंद',
+        },
 
         side_panel: {
             view_all_options: 'सर्व पर्याय पहा...',
@@ -125,12 +127,11 @@ export const mr: LanguageTranslation = {
                 add_view: 'व्ह्यू जोडा',
                 filter: 'फिल्टर',
                 collapse: 'सर्व संकुचित करा',
-                // TODO: Translate
-                clear: 'Clear Filter',
-                no_results: 'No tables found matching your filter.',
-                // TODO: Translate
-                show_list: 'Show Table List',
-                show_dbml: 'Show DBML Editor',
+                clear: 'क्लियर फिल्टर',
+                no_results:
+                    'आपल्या फिल्टरशी जुळणारी कोणतीही सारण्या आढळल्या नाहीत.',
+                show_list: 'सारणी यादी दर्शवा',
+                show_dbml: 'डीबीएमएल संपादक दर्शवा',
 
                 table: {
                     fields: 'फील्ड्स',
@@ -152,10 +153,8 @@ export const mr: LanguageTranslation = {
                         comments: 'टिप्पण्या',
                         no_comments: 'कोणत्याही टिप्पणी नाहीत',
                         delete_field: 'फील्ड हटवा',
-                        // TODO: Translate
                         default_value: 'Default Value',
                         no_default: 'No default',
-                        // TODO: Translate
                         character_length: 'Max Length',
                         precision: 'अचूकता',
                         scale: 'प्रमाण',
@@ -173,8 +172,7 @@ export const mr: LanguageTranslation = {
                         add_field: 'फील्ड जोडा',
                         add_index: 'इंडेक्स जोडा',
                         delete_table: 'टेबल हटवा',
-                        // TODO: Add translations
-                        duplicate_table: 'Duplicate Table',
+                        duplicate_table: 'डुप्लिकेट टेबल',
                     },
                 },
                 empty_state: {
@@ -215,55 +213,55 @@ export const mr: LanguageTranslation = {
                     description: 'सुरू करण्यासाठी एक रिलेशनशिप तयार करा',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
+                areas: 'क्षेत्रे',
+                add_area: 'क्षेत्र जोडा',
+                filter: 'फिल्टर',
+                clear: 'क्लियर फिल्टर',
+                no_results:
+                    'आपल्या फिल्टरशी जुळणारी कोणतीही क्षेत्रे आढळली नाहीत.',
 
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: 'क्षेत्र क्रिया',
+                        edit_name: 'नाव संपादित करा',
+                        delete_area: 'क्षेत्र हटवा',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: 'कोणतेही क्षेत्र नाही',
+                    description: 'प्रारंभ करण्यासाठी एक क्षेत्र तयार करा',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: 'सानुकूल प्रकार',
+                filter: 'फिल्टर',
+                clear: 'क्लियर फिल्टर',
+                no_results:
+                    'आपल्या फिल्टरशी जुळणारे कोणतेही सानुकूल प्रकार आढळले नाहीत.',
                 empty_state: {
-                    title: 'No custom types',
+                    title: 'सानुकूल प्रकार नाहीत',
                     description:
-                        'Custom types will appear here when they are available in your database',
+                        'जेव्हा ते आपल्या डेटाबेसमध्ये उपलब्ध असतील तेव्हा सानुकूल प्रकार येथे दिसतील',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: 'प्रकार',
+                    enum_values: 'एनम मूल्ये',
+                    composite_fields: 'फील्ड्स',
+                    no_fields: 'कोणतीही फील्ड परिभाषित केलेली नाही',
                     no_values: 'कोणतीही enum मूल्ये परिभाषित नाहीत',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: 'फील्ड नाव',
+                    field_type_placeholder: 'प्रकार निवडा',
+                    add_field: 'फील्ड जोडा',
+                    no_fields_tooltip:
+                        'या सानुकूल प्रकारासाठी कोणतीही फील्ड परिभाषित केलेली नाहीत',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: 'क्रिया',
+                        highlight_fields: 'हायलाइट फील्ड',
+                        delete_custom_type: 'हटवा',
+                        clear_field_highlight: 'स्पष्ट हायलाइट',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: 'प्रकार हटवा',
                 },
             },
         },
@@ -281,7 +279,6 @@ export const mr: LanguageTranslation = {
             custom_type_highlight_tooltip:
                 'Highlighting "{{typeName}}" - Click to clear',
             highlight_overlapping_tables: 'ओव्हरलॅपिंग टेबल्स हायलाइट करा',
-            // TODO: Translate
             filter: 'Filter Tables',
         },
 
@@ -306,13 +303,11 @@ export const mr: LanguageTranslation = {
                     step_1: 'टूल्स > पर्याय > क्वेरी परिणाम > SQL सर्व्हर वर जा.',
                     step_2: 'जर तुम्ही "ग्रिडला परिणाम" वापरत असाल, तर नॉन-XML डेटासाठी जास्तीत जास्त वर्ण पुनर्प्राप्ती बदला (9999999 वर सेट करा).',
                 },
-                // TODO: Add translations
                 instructions_link: 'Need help? Watch how',
                 check_script_result: 'Check Script Result',
             },
 
             cancel: 'रद्द करा',
-            // TODO: Add translations
             import_from_file: 'Import from File',
             back: 'मागे',
             empty_diagram: 'रिक्त आरेख',
@@ -330,6 +325,7 @@ export const mr: LanguageTranslation = {
                 tables_count: 'टेबल्स',
             },
             cancel: 'रद्द करा',
+            start_new: 'नवीन आरेखासह प्रारंभ करा',
             open: 'उघडा',
 
             diagram_actions: {
@@ -400,7 +396,6 @@ export const mr: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'रद्द करा',
             export: 'निर्यात करा',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -438,8 +433,6 @@ export const mr: LanguageTranslation = {
             close: 'आता नाही',
             confirm: 'नक्कीच!',
         },
-
-        // TODO: Add translations
         export_diagram_dialog: {
             title: 'Export Diagram',
             description: 'Choose the format for export:',
@@ -455,17 +448,15 @@ export const mr: LanguageTranslation = {
 
         // TO
         import_diagram_dialog: {
-            title: 'Import Diagram',
+            title: 'आयात आकृती',
             description: 'Paste the diagram JSON below:',
             cancel: 'Cancel',
             import: 'Import',
             error: {
-                title: 'Error importing diagram',
-                description:
-                    'The diagram JSON is invalid. Please check the JSON and try again. Need help? support@chartdb.io',
+                title: 'आकृती आयात करणारी त्रुटी',
+                description: 'आकृती जेएसओएन अवैध आहे. ',
             },
         },
-        // TODO: Translate
         import_dbml_dialog: {
             example_title: 'Import Example DBML',
             title: 'Import DBML',
@@ -491,21 +482,16 @@ export const mr: LanguageTranslation = {
             new_table: 'नवीन टेबल',
             new_view: 'नवीन व्ह्यू',
             new_relationship: 'नवीन रिलेशनशिप',
-            // TODO: Translate
             new_area: 'New Area',
         },
 
         table_node_context_menu: {
             edit_table: 'टेबल संपादित करा',
             delete_table: 'टेबल हटवा',
-            duplicate_table: 'Duplicate Table', // TODO: Translate
-            add_relationship: 'Add Relationship', // TODO: Translate
+            duplicate_table: 'डुप्लिकेट टेबल',
+            add_relationship: 'संबंध जोडा',
         },
-
-        // TODO: Add translations
         snap_to_grid_tooltip: 'Snap to Grid (Hold {{key}})',
-
-        // TODO: Add translations
         tool_tips: {
             double_click_to_edit: 'Double-click to edit',
         },

--- a/src/i18n/locales/ne.ts
+++ b/src/i18n/locales/ne.ts
@@ -41,11 +41,9 @@ export const ne: LanguageTranslation = {
                 theme: 'थिम',
                 show_dependencies: 'डिपेन्डेन्सीहरू देखाउनुहोस्',
                 hide_dependencies: 'डिपेन्डेन्सीहरू लुकाउनुहोस्',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'मिनी नक्शा देखाउनुहोस्',
+                hide_minimap: 'मिनी नक्शा लुकाउनुहोस्',
             },
-            // TODO: Translate
             backup: {
                 backup: 'Backup',
                 export_diagram: 'Export Diagram',
@@ -115,6 +113,12 @@ export const ne: LanguageTranslation = {
         copy_to_clipboard: 'क्लिपबोर्डमा प्रतिलिपि गर्नुहोस्',
         copied: 'प्रतिलिपि गरियो!',
 
+        share_table_dialog: {
+            title: 'साझेदारी तालिका',
+            description: 'यस टेबल साझेदारी गर्न तलको लिंक प्रतिलिपि गर्नुहोस्।',
+            close: 'घनिष्ट',
+        },
+
         side_panel: {
             view_all_options: 'सबै विकल्पहरू हेर्नुहोस्',
             tables_section: {
@@ -123,12 +127,10 @@ export const ne: LanguageTranslation = {
                 add_view: 'भ्यू थप्नुहोस्',
                 filter: 'फिल्टर',
                 collapse: 'सबै लुकाउनुहोस्',
-                // TODO: Translate
-                clear: 'Clear Filter',
-                no_results: 'No tables found matching your filter.',
-                // TODO: Translate
-                show_list: 'Show Table List',
-                show_dbml: 'Show DBML Editor',
+                clear: 'खाली फिल्टर',
+                no_results: 'तपाईंको फिल्टर मिल्दो तालिकाहरू फेला परेन।',
+                show_list: 'तालिका सूची देखाउनुहोस्',
+                show_dbml: 'DBML सम्पादक देखाउनुहोस्',
 
                 table: {
                     fields: 'क्षेत्रहरू',
@@ -150,10 +152,8 @@ export const ne: LanguageTranslation = {
                         comments: 'टिप्पणीहरू',
                         no_comments: 'कुनै टिप्पणीहरू छैनन्',
                         delete_field: 'क्षेत्र हटाउनुहोस्',
-                        // TODO: Translate
                         default_value: 'Default Value',
                         no_default: 'No default',
-                        // TODO: Translate
                         character_length: 'Max Length',
                         precision: 'परिशुद्धता',
                         scale: 'स्केल',
@@ -212,55 +212,54 @@ export const ne: LanguageTranslation = {
                     description: 'सुरु गर्नका लागि एक सम्बन्ध बनाउनुहोस्',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
+                areas: 'क्षेत्रहरु',
+                add_area: 'क्षेत्र थप्नुहोस्',
+                filter: 'फिल्टर',
+                clear: 'खाली फिल्टर',
+                no_results: 'कुनै क्षेत्रहरू तपाईको फिल्टर मिल्दैन।',
 
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: 'क्षेत्र कार्यहरू',
+                        edit_name: 'नाम सम्पादन गर्नुहोस्',
+                        delete_area: 'मेटाउने क्षेत्र',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: 'कुनै क्षेत्र छैन',
+                    description: 'सुरू गर्न एक क्षेत्र सिर्जना गर्नुहोस्',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: 'कस्टम प्रकारहरू',
+                filter: 'फिल्टर',
+                clear: 'खाली फिल्टर',
+                no_results:
+                    'तपाईको फिल्टरसँग मेल खाने कुनै कस्टम प्रकारहरू फेला परेन।',
                 empty_state: {
-                    title: 'No custom types',
+                    title: 'कुनै कस्टम प्रकारहरू छैनन्',
                     description:
-                        'Custom types will appear here when they are available in your database',
+                        'कस्टम प्रकारहरू यहाँ देखा पर्नेछन् जब तिनीहरू तपाईंको डाटाबेसमा उपलब्ध छन्',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: 'दयालु',
+                    enum_values: 'म्यूम मानहरू',
+                    composite_fields: 'फाराटहरू',
+                    no_fields: 'कुनै क्षेत्रहरू परिभाषित छैन',
                     no_values: 'कुनै enum मानहरू परिभाषित छैनन्',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: 'क्षेत्रको नाम',
+                    field_type_placeholder: 'टाइप चयन गर्नुहोस्',
+                    add_field: 'फाँट थप्नुहोस्',
+                    no_fields_tooltip:
+                        'यस कस्टम प्रकारका लागि परिभाषित क्षेत्रहरू परिभाषित छैन',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: 'काम',
+                        highlight_fields: 'हाइलाइट फिल्डहरू',
+                        delete_custom_type: 'मेटाउन',
+                        clear_field_highlight: 'स्पष्ट हाइलाइट',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: 'हावा मेटाउनुहोस्',
                 },
             },
         },
@@ -279,7 +278,6 @@ export const ne: LanguageTranslation = {
                 'Highlighting "{{typeName}}" - Click to clear',
             highlight_overlapping_tables:
                 'अतिरिक्त तालिकाहरू हाइलाइट गर्नुहोस्',
-            // TODO: Translate
             filter: 'Filter Tables',
         },
 
@@ -327,6 +325,7 @@ export const ne: LanguageTranslation = {
                 tables_count: 'तालिकाहरू',
             },
             cancel: 'रद्द गर्नुहोस्',
+            start_new: 'नयाँ डायाग्रामबाट सुरु गर्नुहोस्',
             open: 'खोल्नुहोस्',
 
             diagram_actions: {
@@ -397,7 +396,6 @@ export const ne: LanguageTranslation = {
             scale_4x: '४x',
             cancel: 'रद्द गर्नुहोस्',
             export: 'निर्यात गर्नुहोस्',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -459,7 +457,6 @@ export const ne: LanguageTranslation = {
                     'डायाग्राम JSON अमान्य छ। कृपया JSON जाँच गर्नुहोस् र पुन: प्रयास गर्नुहोस्। मद्दत चाहिन्छ? support@chartdb.io मा सम्पर्क गर्नुहोस्',
             },
         },
-        // TODO: Translate
         import_dbml_dialog: {
             example_title: 'Import Example DBML',
             title: 'Import DBML',
@@ -485,7 +482,6 @@ export const ne: LanguageTranslation = {
             new_table: 'नयाँ तालिका',
             new_view: 'नयाँ भ्यू',
             new_relationship: 'नयाँ सम्बन्ध',
-            // TODO: Translate
             new_area: 'New Area',
         },
 
@@ -493,7 +489,7 @@ export const ne: LanguageTranslation = {
             edit_table: 'तालिका सम्पादन गर्नुहोस्',
             duplicate_table: 'तालिका नक्कली गर्नुहोस्',
             delete_table: 'तालिका हटाउनुहोस्',
-            add_relationship: 'Add Relationship', // TODO: Translate
+            add_relationship: 'सम्बन्ध जोड्नुहोस्',
         },
 
         snap_to_grid_tooltip: 'ग्रिडमा स्न्याप गर्नुहोस् ({{key}} थिच्नुहोस)',

--- a/src/i18n/locales/pt_BR.ts
+++ b/src/i18n/locales/pt_BR.ts
@@ -41,11 +41,9 @@ export const pt_BR: LanguageTranslation = {
                 theme: 'Tema',
                 show_dependencies: 'Mostrar Dependências',
                 hide_dependencies: 'Ocultar Dependências',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'Mostrar Mini Mapa',
+                hide_minimap: 'Ocultar Mini Mapa',
             },
-            // TODO: Translate
             backup: {
                 backup: 'Backup',
                 export_diagram: 'Exportar Diagrama',
@@ -115,6 +113,12 @@ export const pt_BR: LanguageTranslation = {
         copy_to_clipboard: 'Copiar para a Área de Transferência',
         copied: 'Copiado!',
 
+        share_table_dialog: {
+            title: 'Compartilhe a tabela',
+            description: 'Copie o link abaixo para compartilhar esta tabela.',
+            close: 'Fechar',
+        },
+
         side_panel: {
             view_all_options: 'Ver todas as Opções...',
             tables_section: {
@@ -123,12 +127,10 @@ export const pt_BR: LanguageTranslation = {
                 add_view: 'Adicionar Visualização',
                 filter: 'Filtrar',
                 collapse: 'Colapsar Todas',
-                // TODO: Translate
-                clear: 'Clear Filter',
-                no_results: 'No tables found matching your filter.',
-                // TODO: Translate
-                show_list: 'Show Table List',
-                show_dbml: 'Show DBML Editor',
+                clear: 'Filtro transparente',
+                no_results: 'Nenhuma mesa encontrou combinando seu filtro.',
+                show_list: 'Mostrar lista de tabela',
+                show_dbml: 'Mostrar editor DBML',
 
                 table: {
                     fields: 'Campos',
@@ -150,10 +152,8 @@ export const pt_BR: LanguageTranslation = {
                         comments: 'Comentários',
                         no_comments: 'Sem comentários',
                         delete_field: 'Excluir Campo',
-                        // TODO: Translate
                         default_value: 'Default Value',
                         no_default: 'No default',
-                        // TODO: Translate
                         character_length: 'Max Length',
                         precision: 'Precisão',
                         scale: 'Escala',
@@ -170,7 +170,7 @@ export const pt_BR: LanguageTranslation = {
                         change_schema: 'Alterar Esquema',
                         add_field: 'Adicionar Campo',
                         add_index: 'Adicionar Índice',
-                        duplicate_table: 'Duplicate Table', // TODO: Translate
+                        duplicate_table: 'Tabela duplicada',
                         delete_table: 'Excluir Tabela',
                     },
                 },
@@ -212,55 +212,55 @@ export const pt_BR: LanguageTranslation = {
                     description: 'Crie um relacionamento para começar',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
+                areas: 'Áreas',
+                add_area: 'Adicione área',
+                filter: 'Filtro',
+                clear: 'Filtro transparente',
+                no_results:
+                    'Nenhuma área encontrou correspondendo ao seu filtro.',
 
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: 'Ações da área',
+                        edit_name: 'Nome de edição',
+                        delete_area: 'Excluir área',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: 'Sem áreas',
+                    description: 'Crie uma área para começar',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: 'Tipos personalizados',
+                filter: 'Filtro',
+                clear: 'Filtro transparente',
+                no_results:
+                    'Não há tipos personalizados encontrados correspondendo ao seu filtro.',
                 empty_state: {
-                    title: 'No custom types',
+                    title: 'Sem tipos personalizados',
                     description:
-                        'Custom types will appear here when they are available in your database',
+                        'Os tipos personalizados aparecerão aqui quando estiverem disponíveis em seu banco de dados',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: 'Tipo',
+                    enum_values: 'Valores da enumeração',
+                    composite_fields: 'Campos',
+                    no_fields: 'Nenhum campo definido',
                     no_values: 'Nenhum valor de enum definido',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: 'Nome do campo',
+                    field_type_placeholder: 'Selecione Tipo',
+                    add_field: 'Adicione o campo',
+                    no_fields_tooltip:
+                        'Nenhum campo definido para este tipo personalizado',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: 'Ações',
+                        highlight_fields: 'Destaque campos',
+                        delete_custom_type: 'Excluir',
+                        clear_field_highlight: 'Destaque claro',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: 'Excluir tipo',
                 },
             },
         },
@@ -278,7 +278,6 @@ export const pt_BR: LanguageTranslation = {
             custom_type_highlight_tooltip:
                 'Highlighting "{{typeName}}" - Click to clear',
             highlight_overlapping_tables: 'Destacar Tabelas Sobrepostas',
-            // TODO: Translate
             filter: 'Filter Tables',
         },
 
@@ -309,7 +308,6 @@ export const pt_BR: LanguageTranslation = {
 
             cancel: 'Cancelar',
             back: 'Voltar',
-            // TODO: Translate
             import_from_file: 'Import from File',
             empty_diagram: 'Diagrama vazio',
             continue: 'Continuar',
@@ -326,6 +324,7 @@ export const pt_BR: LanguageTranslation = {
                 tables_count: 'Tabelas',
             },
             cancel: 'Cancelar',
+            start_new: 'Começar com um novo diagrama',
             open: 'Abrir',
 
             diagram_actions: {
@@ -396,7 +395,6 @@ export const pt_BR: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'Cancelar',
             export: 'Exportar',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -434,7 +432,6 @@ export const pt_BR: LanguageTranslation = {
             close: 'Agora não',
             confirm: 'Claro!',
         },
-        // TODO: Translate
         export_diagram_dialog: {
             title: 'Export Diagram',
             description: 'Choose the format for export:',
@@ -447,19 +444,16 @@ export const pt_BR: LanguageTranslation = {
                     'Something went wrong. Need help? support@chartdb.io',
             },
         },
-        // TODO: Translate
         import_diagram_dialog: {
-            title: 'Import Diagram',
+            title: 'Diagrama de importação',
             description: 'Paste the diagram JSON below:',
             cancel: 'Cancel',
             import: 'Import',
             error: {
-                title: 'Error importing diagram',
-                description:
-                    'The diagram JSON is invalid. Please check the JSON and try again. Need help? support@chartdb.io',
+                title: 'Erro de importação de diagrama',
+                description: 'O diagrama JSON é inválido. ',
             },
         },
-        // TODO: Translate
         import_dbml_dialog: {
             example_title: 'Import Example DBML',
             title: 'Import DBML',
@@ -484,18 +478,15 @@ export const pt_BR: LanguageTranslation = {
             new_table: 'Nova Tabela',
             new_view: 'Nova Visualização',
             new_relationship: 'Novo Relacionamento',
-            // TODO: Translate
             new_area: 'New Area',
         },
 
         table_node_context_menu: {
             edit_table: 'Editar Tabela',
-            duplicate_table: 'Duplicate Table', // TODO: Translate
+            duplicate_table: 'Tabela duplicada',
             delete_table: 'Excluir Tabela',
-            add_relationship: 'Add Relationship', // TODO: Translate
+            add_relationship: 'Adicionar relacionamento',
         },
-
-        // TODO: Add translations
         snap_to_grid_tooltip: 'Snap to Grid (Hold {{key}})',
 
         tool_tips: {

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -147,7 +147,6 @@ export const ru: LanguageTranslation = {
                         comments: 'Комментарии',
                         no_comments: 'Нет комментария',
                         delete_field: 'Удалить поле',
-                        // TODO: Translate
                         default_value: 'Default Value',
                         no_default: 'No default',
                         character_length: 'Макс. длина',
@@ -230,34 +229,35 @@ export const ru: LanguageTranslation = {
                     description: 'Создайте область, чтобы начать',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: 'Пользовательские типы',
+                filter: 'Фильтр',
+                clear: 'Чистый фильтр',
+                no_results:
+                    'Нет пользовательских типов, которые соответствуют вашему фильтру.',
                 empty_state: {
-                    title: 'No custom types',
+                    title: 'Нет пользовательских типов',
                     description:
-                        'Custom types will appear here when they are available in your database',
+                        'Пользовательские типы появятся здесь, когда они доступны в вашей базе данных',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: 'Добрый',
+                    enum_values: 'Enum значения',
+                    composite_fields: 'Поля',
+                    no_fields: 'Поля не определены',
                     no_values: 'Значения перечисления не определены',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: 'Имя поля',
+                    field_type_placeholder: 'Выберите тип',
+                    add_field: 'Добавить поле',
+                    no_fields_tooltip:
+                        'Поля не определены для этого пользовательского типа',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: 'Действия',
+                        highlight_fields: 'Выделите поля',
+                        delete_custom_type: 'Удалить',
+                        clear_field_highlight: 'Ясная выделение',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: 'Удалить тип',
                 },
             },
         },
@@ -275,7 +275,6 @@ export const ru: LanguageTranslation = {
             custom_type_highlight_tooltip:
                 'Highlighting "{{typeName}}" - Click to clear',
             highlight_overlapping_tables: 'Выделение перекрывающихся таблиц',
-            // TODO: Translate
             filter: 'Filter Tables',
         },
 
@@ -323,6 +322,7 @@ export const ru: LanguageTranslation = {
                 tables_count: 'Таблицы',
             },
             cancel: 'Отмена',
+            start_new: 'Начать с новой диаграммы',
             open: 'Открыть',
 
             diagram_actions: {
@@ -393,7 +393,6 @@ export const ru: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'Отменить',
             export: 'Экспортировать',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -492,6 +491,14 @@ export const ru: LanguageTranslation = {
 
         copy_to_clipboard: 'Скопировать в буфер обмена',
         copied: 'Скопировано!',
+
+        share_table_dialog: {
+            title: 'Поделиться таблицей',
+            description:
+                'Скопируйте ссылку ниже, чтобы поделиться этой таблицей.',
+            close: 'Закрывать',
+        },
+
         snap_to_grid_tooltip: 'Выравнивание по сетке (Удерживайте {{key}})',
         tool_tips: {
             double_click_to_edit: 'Кликните дважды, чтобы изменить',

--- a/src/i18n/locales/te.ts
+++ b/src/i18n/locales/te.ts
@@ -41,11 +41,9 @@ export const te: LanguageTranslation = {
                 theme: 'థీమ్',
                 show_dependencies: 'ఆధారాలు చూపించండి',
                 hide_dependencies: 'ఆధారాలను దాచండి',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'మినీ మ్యాప్ చూపించు',
+                hide_minimap: 'మినీ మ్యాప్ దాచు',
             },
-            // TODO: Translate
             backup: {
                 backup: 'Backup',
                 export_diagram: 'Export Diagram',
@@ -115,6 +113,13 @@ export const te: LanguageTranslation = {
         copy_to_clipboard: 'క్లిప్బోర్డుకు కాపీ చేయండి',
         copied: 'కాపీ చేయబడింది!',
 
+        share_table_dialog: {
+            title: 'షేర్ పట్టిక',
+            description:
+                'ఈ పట్టికను భాగస్వామ్యం చేయడానికి క్రింది లింక్‌ను కాపీ చేయండి.',
+            close: 'దగ్గరగా',
+        },
+
         side_panel: {
             view_all_options: 'అన్ని ఎంపికలను చూడండి...',
             tables_section: {
@@ -123,12 +128,10 @@ export const te: LanguageTranslation = {
                 add_view: 'వ్యూ జోడించండి',
                 filter: 'ఫిల్టర్',
                 collapse: 'అన్ని కూల్ చేయి',
-                // TODO: Translate
-                clear: 'Clear Filter',
-                no_results: 'No tables found matching your filter.',
-                // TODO: Translate
-                show_list: 'Show Table List',
-                show_dbml: 'Show DBML Editor',
+                clear: 'క్లియర్ ఫిల్టర్',
+                no_results: 'మీ ఫిల్టర్‌కు సరిపోయే పట్టికలు కనుగొనబడలేదు.',
+                show_list: 'పట్టిక జాబితాను చూపించు',
+                show_dbml: 'DBML ఎడిటర్ చూపించు',
 
                 table: {
                     fields: 'ఫీల్డులు',
@@ -150,10 +153,8 @@ export const te: LanguageTranslation = {
                         comments: 'వ్యాఖ్యలు',
                         no_comments: 'వ్యాఖ్యలు లేవు',
                         delete_field: 'ఫీల్డ్ తొలగించు',
-                        // TODO: Translate
                         default_value: 'Default Value',
                         no_default: 'No default',
-                        // TODO: Translate
                         character_length: 'Max Length',
                         precision: 'సూక్ష్మత',
                         scale: 'స్కేల్',
@@ -170,8 +171,7 @@ export const te: LanguageTranslation = {
                         change_schema: 'స్కీమాను మార్చు',
                         add_field: 'ఫీల్డ్ జోడించు',
                         add_index: 'ఇండెక్స్ జోడించు',
-                        // TODO: Translate
-                        duplicate_table: 'Duplicate Table',
+                        duplicate_table: 'నకిలీ పట్టిక',
                         delete_table: 'పట్టికను తొలగించు',
                     },
                 },
@@ -213,55 +213,54 @@ export const te: LanguageTranslation = {
                     description: 'ప్రారంభించడానికి ఒక సంబంధం సృష్టించండి',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
+                areas: 'ప్రాంతాలు',
+                add_area: 'ప్రాంతాన్ని జోడించండి',
+                filter: 'ఫిల్టర్',
+                clear: 'క్లియర్ ఫిల్టర్',
+                no_results: 'మీ ఫిల్టర్‌కు సరిపోయే ప్రాంతాలు ఏవీ కనుగొనబడలేదు.',
 
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: 'ప్రాంత చర్యలు',
+                        edit_name: 'పేరును సవరించండి',
+                        delete_area: 'ప్రాంతం తొలగించు',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: 'ప్రాంతాలు లేవు',
+                    description: 'ప్రారంభించడానికి ఒక ప్రాంతాన్ని సృష్టించండి',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: 'అనుకూల రకాలు',
+                filter: 'ఫిల్టర్',
+                clear: 'క్లియర్ ఫిల్టర్',
+                no_results:
+                    'మీ ఫిల్టర్‌కు సరిపోయే కస్టమ్ రకాలు ఏవీ కనుగొనబడలేదు.',
                 empty_state: {
-                    title: 'No custom types',
+                    title: 'అనుకూల రకాలు లేవు',
                     description:
-                        'Custom types will appear here when they are available in your database',
+                        'మీ డేటాబేస్లో అందుబాటులో ఉన్నప్పుడు అనుకూల రకాలు ఇక్కడ కనిపిస్తాయి',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: 'రకమైన',
+                    enum_values: 'ENUM విలువలు',
+                    composite_fields: 'ఫీల్డ్స్',
+                    no_fields: 'ఏ ఫీల్డ్‌లు నిర్వచించబడలేదు',
                     no_values: 'ఏ enum విలువలు నిర్వచించబడలేదు',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: 'ఫీల్డ్ పేరు',
+                    field_type_placeholder: 'రకాన్ని ఎంచుకోండి',
+                    add_field: 'ఫీల్డ్ జోడించండి',
+                    no_fields_tooltip:
+                        'ఈ కస్టమ్ రకం కోసం ఫీల్డ్‌లు నిర్వచించబడలేదు',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: 'చర్యలు',
+                        highlight_fields: 'ఫీల్డ్‌లను హైలైట్ చేయండి',
+                        delete_custom_type: 'తొలగించు',
+                        clear_field_highlight: 'క్లియర్ హైలైట్',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: 'రకాన్ని తొలగించండి',
                 },
             },
         },
@@ -279,7 +278,6 @@ export const te: LanguageTranslation = {
             custom_type_highlight_tooltip:
                 'Highlighting "{{typeName}}" - Click to clear',
             highlight_overlapping_tables: 'అవకాశించు పట్టికలను హైలైట్ చేయండి',
-            // TODO: Translate
             filter: 'Filter Tables',
         },
 
@@ -309,7 +307,6 @@ export const te: LanguageTranslation = {
             },
 
             cancel: 'రద్దు',
-            // TODO: Translate
             import_from_file: 'Import from File',
             back: 'తిరుగు',
             empty_diagram: 'ఖాళీ చిత్రము',
@@ -327,6 +324,7 @@ export const te: LanguageTranslation = {
                 tables_count: 'పట్టికలు',
             },
             cancel: 'రద్దు',
+            start_new: 'కొత్త డయాగ్రామ్‌తో ప్రారంభించండి',
             open: 'తెరవు',
 
             diagram_actions: {
@@ -397,7 +395,6 @@ export const te: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'రద్దు',
             export: 'ఎగుమతి',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -435,8 +432,6 @@ export const te: LanguageTranslation = {
             close: 'ఇప్పుడు కాదు',
             confirm: 'ఖచ్చితంగా!',
         },
-
-        // TODO: Translate
         export_diagram_dialog: {
             title: 'Export Diagram',
             description: 'Choose the format for export:',
@@ -449,20 +444,16 @@ export const te: LanguageTranslation = {
                     'Something went wrong. Need help? support@chartdb.io',
             },
         },
-
-        // TODO: Translate
         import_diagram_dialog: {
-            title: 'Import Diagram',
+            title: 'దిగుమతి రేఖాచిత్రం',
             description: 'Paste the diagram JSON below:',
             cancel: 'Cancel',
             import: 'Import',
             error: {
-                title: 'Error importing diagram',
-                description:
-                    'The diagram JSON is invalid. Please check the JSON and try again. Need help? support@chartdb.io',
+                title: 'రేఖాచిత్రాన్ని దిగుమతి చేయడంలో లోపం',
+                description: 'రేఖాచిత్రం JSON చెల్లదు. ',
             },
         },
-        // TODO: Translate
         import_dbml_dialog: {
             example_title: 'Import Example DBML',
             title: 'Import DBML',
@@ -488,21 +479,16 @@ export const te: LanguageTranslation = {
             new_table: 'కొత్త పట్టిక',
             new_view: 'కొత్త వ్యూ',
             new_relationship: 'కొత్త సంబంధం',
-            // TODO: Translate
             new_area: 'New Area',
         },
 
         table_node_context_menu: {
             edit_table: 'పట్టికను సవరించు',
-            duplicate_table: 'Duplicate Table', // TODO: Translate
+            duplicate_table: 'నకిలీ పట్టిక',
             delete_table: 'పట్టికను తొలగించు',
-            add_relationship: 'Add Relationship', // TODO: Translate
+            add_relationship: 'సంబంధాన్ని జోడించండి',
         },
-
-        // TODO: Translate
         snap_to_grid_tooltip: 'Snap to Grid (Hold {{key}})',
-
-        // TODO: Translate
         tool_tips: {
             double_click_to_edit: 'Double-click to edit',
         },

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -41,11 +41,9 @@ export const tr: LanguageTranslation = {
                 theme: 'Tema',
                 show_dependencies: 'Bağımlılıkları Göster',
                 hide_dependencies: 'Bağımlılıkları Gizle',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'Mini Haritayı Göster',
+                hide_minimap: 'Mini Haritayı Gizle',
             },
-            // TODO: Translate
             backup: {
                 backup: 'Backup',
                 export_diagram: 'Export Diagram',
@@ -114,6 +112,14 @@ export const tr: LanguageTranslation = {
         show_less: 'Daha Az Göster',
         copy_to_clipboard: 'Panoya Kopyala',
         copied: 'Kopyalandı!',
+
+        share_table_dialog: {
+            title: 'Paylaşım Tablosu',
+            description:
+                'Bu tabloyu paylaşmak için aşağıdaki bağlantıyı kopyalayın.',
+            close: 'Kapalı',
+        },
+
         side_panel: {
             view_all_options: 'Tüm Seçenekleri Gör...',
             tables_section: {
@@ -122,12 +128,10 @@ export const tr: LanguageTranslation = {
                 add_view: 'Görünüm Ekle',
                 filter: 'Filtrele',
                 collapse: 'Hepsini Daralt',
-                // TODO: Translate
-                clear: 'Clear Filter',
-                no_results: 'No tables found matching your filter.',
-                // TODO: Translate
-                show_list: 'Show Table List',
-                show_dbml: 'Show DBML Editor',
+                clear: 'Filtre temizlemek',
+                no_results: 'Filtrenizi eşleştiren hiçbir tablo bulunamadı.',
+                show_list: 'Tablo listesini göster',
+                show_dbml: 'Dbml editörünü göster',
 
                 table: {
                     fields: 'Alanlar',
@@ -149,10 +153,8 @@ export const tr: LanguageTranslation = {
                         comments: 'Yorumlar',
                         no_comments: 'Yorum yok',
                         delete_field: 'Alanı Sil',
-                        // TODO: Translate
                         default_value: 'Default Value',
                         no_default: 'No default',
-                        // TODO: Translate
                         character_length: 'Max Length',
                         precision: 'Hassasiyet',
                         scale: 'Ölçek',
@@ -169,8 +171,7 @@ export const tr: LanguageTranslation = {
                         change_schema: 'Şemayı Değiştir',
                         add_field: 'Alan Ekle',
                         add_index: 'İndeks Ekle',
-                        // TODO: Translate
-                        duplicate_table: 'Duplicate Table',
+                        duplicate_table: 'Yinelenen tablo',
                         delete_table: 'Tabloyu Sil',
                     },
                 },
@@ -212,55 +213,52 @@ export const tr: LanguageTranslation = {
                     description: 'Başlamak için bir ilişki oluşturun',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
+                areas: 'Alanlar',
+                add_area: 'Alan ekle',
+                filter: 'Filtre',
+                clear: 'Filtre temizlemek',
+                no_results: 'Filtrenizle eşleşen hiçbir alan bulunamadı.',
 
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: 'Alan eylemleri',
+                        edit_name: 'Adı Düzenle',
+                        delete_area: 'Alanı Sil',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: 'Alan yok',
+                    description: 'Başlamak için bir alan oluşturun',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: 'Özel türler',
+                filter: 'Filtre',
+                clear: 'Filtre temizlemek',
+                no_results: 'Filtrenizle eşleşen özel tür bulunmadı.',
                 empty_state: {
-                    title: 'No custom types',
+                    title: 'Özel Tür yok',
                     description:
-                        'Custom types will appear here when they are available in your database',
+                        'Özel türler, veritabanınızda mevcut olduklarında burada görünecektir',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: 'Tür',
+                    enum_values: 'Enum değerleri',
+                    composite_fields: 'Alanlar',
+                    no_fields: 'Alan tanımlanmadı',
                     no_values: 'Tanımlanmış enum değeri yok',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: 'Saha adı',
+                    field_type_placeholder: 'Türü seçin',
+                    add_field: 'Alan ekle',
+                    no_fields_tooltip: 'Bu özel tür için tanımlanmadı',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: 'Eylem',
+                        highlight_fields: 'Alanları Vurgulamak',
+                        delete_custom_type: 'Silmek',
+                        clear_field_highlight: 'Net vurgu',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: 'Sil Tür',
                 },
             },
         },
@@ -277,7 +275,6 @@ export const tr: LanguageTranslation = {
             custom_type_highlight_tooltip:
                 'Highlighting "{{typeName}}" - Click to clear',
             highlight_overlapping_tables: 'Çakışan Tabloları Vurgula',
-            // TODO: Translate
             filter: 'Filter Tables',
         },
         new_diagram_dialog: {
@@ -304,7 +301,6 @@ export const tr: LanguageTranslation = {
                     'Yardıma mı ihtiyacınız var? İzlemek için tıklayın',
                 check_script_result: 'Komut Dosyası Sonucunu Kontrol Et',
             },
-            // TODO: Translate
             import_from_file: 'Import from File',
             cancel: 'İptal',
             back: 'Geri',
@@ -322,6 +318,7 @@ export const tr: LanguageTranslation = {
                 tables_count: 'Tablolar',
             },
             cancel: 'İptal',
+            start_new: 'Yeni bir diyagramla başlayın',
             open: 'Aç',
 
             diagram_actions: {
@@ -389,7 +386,6 @@ export const tr: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'İptal',
             export: 'Dışa Aktar',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -424,7 +420,6 @@ export const tr: LanguageTranslation = {
             close: 'Şimdi Değil',
             confirm: 'Tabii ki!',
         },
-        // TODO: Translate
         export_diagram_dialog: {
             title: 'Export Diagram',
             description: 'Choose the format for export:',
@@ -437,19 +432,16 @@ export const tr: LanguageTranslation = {
                     'Something went wrong. Need help? support@chartdb.io',
             },
         },
-        // TODO: Translate
         import_diagram_dialog: {
-            title: 'Import Diagram',
+            title: 'İthalat Şeması',
             description: 'Paste the diagram JSON below:',
             cancel: 'Cancel',
             import: 'Import',
             error: {
-                title: 'Error importing diagram',
-                description:
-                    'The diagram JSON is invalid. Please check the JSON and try again. Need help? support@chartdb.io',
+                title: 'Diyagramı İçe Aktarma Hatası',
+                description: 'JSON diyagramı geçersiz. ',
             },
         },
-        // TODO: Translate
         import_dbml_dialog: {
             example_title: 'Import Example DBML',
             title: 'Import DBML',
@@ -473,20 +465,15 @@ export const tr: LanguageTranslation = {
             new_table: 'Yeni Tablo',
             new_view: 'Yeni Görünüm',
             new_relationship: 'Yeni İlişki',
-            // TODO: Translate
             new_area: 'New Area',
         },
         table_node_context_menu: {
             edit_table: 'Tabloyu Düzenle',
             delete_table: 'Tabloyu Sil',
-            duplicate_table: 'Duplicate Table', // TODO: Translate
-            add_relationship: 'Add Relationship', // TODO: Translate
+            duplicate_table: 'Yinelenen tablo',
+            add_relationship: 'İlişki eklemek',
         },
-
-        // TODO: Translate
         snap_to_grid_tooltip: 'Snap to Grid (Hold {{key}})',
-
-        // TODO: Translate
         tool_tips: {
             double_click_to_edit: 'Double-click to edit',
         },

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -113,6 +113,13 @@ export const uk: LanguageTranslation = {
         copy_to_clipboard: 'Копіювати в буфер обміну',
         copied: 'Скопійовано!',
 
+        share_table_dialog: {
+            title: 'Поділитися таблицею',
+            description:
+                'Скопіюйте посилання нижче, щоб поділитися цією таблицею.',
+            close: 'Закривати',
+        },
+
         side_panel: {
             view_all_options: 'Переглянути всі параметри…',
             tables_section: {
@@ -121,12 +128,11 @@ export const uk: LanguageTranslation = {
                 add_view: 'Додати представлення',
                 filter: 'Фільтр',
                 collapse: 'Згорнути все',
-                // TODO: Translate
-                clear: 'Clear Filter',
-                no_results: 'No tables found matching your filter.',
-                // TODO: Translate
-                show_list: 'Show Table List',
-                show_dbml: 'Show DBML Editor',
+                clear: 'Прозорий фільтр',
+                no_results:
+                    'Жодних таблиць не знайдено, що відповідає вашому фільтра.',
+                show_list: 'Показати список таблиць',
+                show_dbml: 'Показати редактор DBML',
 
                 table: {
                     fields: 'Поля',
@@ -148,10 +154,8 @@ export const uk: LanguageTranslation = {
                         comments: 'Коментарі',
                         no_comments: 'Немає коментарів',
                         delete_field: 'Видалити поле',
-                        // TODO: Translate
                         default_value: 'Default Value',
                         no_default: 'No default',
-                        // TODO: Translate
                         character_length: 'Max Length',
                         precision: 'Точність',
                         scale: 'Масштаб',
@@ -210,55 +214,55 @@ export const uk: LanguageTranslation = {
                     description: 'Створіть зв’язок, щоб почати',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
+                areas: 'Райони',
+                add_area: 'Додати площу',
+                filter: 'Фільтрувати',
+                clear: 'Прозорий фільтр',
+                no_results:
+                    'Жодних областей не знайдено, що відповідає вашому фільтра.',
 
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: 'Дії області',
+                        edit_name: 'Назва редагування',
+                        delete_area: 'Видалити площу',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: 'Немає областей',
+                    description: 'Створіть область для початку',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: 'Спеціальні типи',
+                filter: 'Фільтрувати',
+                clear: 'Прозорий фільтр',
+                no_results:
+                    'Не знайдено спеціальних типів, що відповідають вашому фільтра.',
                 empty_state: {
-                    title: 'No custom types',
+                    title: 'Немає власних типів',
                     description:
-                        'Custom types will appear here when they are available in your database',
+                        'Спеціальні типи з’являться тут, коли вони будуть доступні у вашій базі даних',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: 'Вид',
+                    enum_values: 'Значення перелічення',
+                    composite_fields: 'Поля',
+                    no_fields: 'Не визначені поля',
                     no_values: 'Значення переліку не визначені',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: 'Назва поля',
+                    field_type_placeholder: 'Виберіть Тип',
+                    add_field: 'Додати поле',
+                    no_fields_tooltip:
+                        'Не визначені для цього типу полів для цього користувальницького типу',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: 'Дії',
+                        highlight_fields: 'Виділіть поля',
+                        delete_custom_type: 'Видаляти',
+                        clear_field_highlight: 'Чітка родзинка',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: 'Тип видалення',
                 },
             },
         },
@@ -276,7 +280,6 @@ export const uk: LanguageTranslation = {
             custom_type_highlight_tooltip:
                 'Highlighting "{{typeName}}" - Click to clear',
             highlight_overlapping_tables: 'Показати таблиці, що перекриваються',
-            // TODO: Translate
             filter: 'Filter Tables',
         },
 
@@ -324,6 +327,7 @@ export const uk: LanguageTranslation = {
                 tables_count: 'Таблиці',
             },
             cancel: 'Скасувати',
+            start_new: 'Почати з нової діаграми',
             open: 'Відкрити',
 
             diagram_actions: {
@@ -394,7 +398,6 @@ export const uk: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'Скасувати',
             export: 'Експортувати',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -454,7 +457,6 @@ export const uk: LanguageTranslation = {
                     'JSON діаграми є неправильним. Будь ласка, перевірте JSON і спробуйте ще раз. Потрібна допомога? support@chartdb.io',
             },
         },
-        // TODO: Translate
         import_dbml_dialog: {
             example_title: 'Import Example DBML',
             title: 'Import DBML',
@@ -479,7 +481,6 @@ export const uk: LanguageTranslation = {
             new_table: 'Нова таблиця',
             new_view: 'Нове представлення',
             new_relationship: 'Новий звʼязок',
-            // TODO: Translate
             new_area: 'New Area',
         },
 
@@ -487,7 +488,7 @@ export const uk: LanguageTranslation = {
             edit_table: 'Редагувати таблицю',
             duplicate_table: 'Дублювати таблицю',
             delete_table: 'Видалити таблицю',
-            add_relationship: 'Add Relationship', // TODO: Translate
+            add_relationship: 'Додати стосунки',
         },
 
         snap_to_grid_tooltip: 'Вирівнювати за сіткою (Отримуйте {{key}})',

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -41,9 +41,8 @@ export const vi: LanguageTranslation = {
                 theme: 'Chủ đề',
                 show_dependencies: 'Hiển thị các phụ thuộc',
                 hide_dependencies: 'Ẩn các phụ thuộc',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'Hiển thị bản đồ nhỏ',
+                hide_minimap: 'Ẩn bản đồ nhỏ',
             },
             backup: {
                 backup: 'Hỗ trợ',
@@ -114,6 +113,12 @@ export const vi: LanguageTranslation = {
         copy_to_clipboard: 'Sao chép vào bảng tạm',
         copied: 'Đã sao chép!',
 
+        share_table_dialog: {
+            title: 'Bảng chia sẻ',
+            description: 'Sao chép liên kết dưới đây để chia sẻ bảng này.',
+            close: 'Đóng',
+        },
+
         side_panel: {
             view_all_options: 'Xem tất cả tùy chọn...',
             tables_section: {
@@ -122,12 +127,10 @@ export const vi: LanguageTranslation = {
                 add_view: 'Thêm Chế độ xem',
                 filter: 'Lọc',
                 collapse: 'Thu gọn tất cả',
-                // TODO: Translate
-                clear: 'Clear Filter',
-                no_results: 'No tables found matching your filter.',
-                // TODO: Translate
-                show_list: 'Show Table List',
-                show_dbml: 'Show DBML Editor',
+                clear: 'Xóa bộ lọc',
+                no_results: 'Không tìm thấy bảng phù hợp với bộ lọc của bạn.',
+                show_list: 'Hiển thị danh sách bảng',
+                show_dbml: 'Hiển thị biên tập DBML',
 
                 table: {
                     fields: 'Trường',
@@ -149,10 +152,8 @@ export const vi: LanguageTranslation = {
                         comments: 'Bình luận',
                         no_comments: 'Không có bình luận',
                         delete_field: 'Xóa trường',
-                        // TODO: Translate
                         default_value: 'Default Value',
                         no_default: 'No default',
-                        // TODO: Translate
                         character_length: 'Max Length',
                         precision: 'Độ chính xác',
                         scale: 'Tỷ lệ',
@@ -211,55 +212,55 @@ export const vi: LanguageTranslation = {
                     description: 'Tạo một quan hệ để bắt đầu',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
+                areas: 'Khu vực',
+                add_area: 'Thêm khu vực',
+                filter: 'Lọc',
+                clear: 'Xóa bộ lọc',
+                no_results:
+                    'Không có khu vực nào được tìm thấy phù hợp với bộ lọc của bạn.',
 
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: 'Hành động khu vực',
+                        edit_name: 'Chỉnh sửa tên',
+                        delete_area: 'Xóa khu vực',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: 'Không có khu vực',
+                    description: 'Tạo một khu vực để bắt đầu',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: 'Các loại tùy chỉnh',
+                filter: 'Lọc',
+                clear: 'Xóa bộ lọc',
+                no_results:
+                    'Không có loại tùy chỉnh nào được tìm thấy phù hợp với bộ lọc của bạn.',
                 empty_state: {
-                    title: 'No custom types',
+                    title: 'Không có loại tùy chỉnh',
                     description:
-                        'Custom types will appear here when they are available in your database',
+                        'Các loại tùy chỉnh sẽ xuất hiện ở đây khi chúng có sẵn trong cơ sở dữ liệu của bạn',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: 'Loại',
+                    enum_values: 'Giá trị enum',
+                    composite_fields: 'Cánh đồng',
+                    no_fields: 'Không có trường được xác định',
                     no_values: 'Không có giá trị enum được định nghĩa',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: 'Tên hiện trường',
+                    field_type_placeholder: 'Chọn Loại',
+                    add_field: 'Thêm trường',
+                    no_fields_tooltip:
+                        'Không có trường được xác định cho loại tùy chỉnh này',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: 'Hành động',
+                        highlight_fields: 'Làm nổi bật các trường',
+                        delete_custom_type: 'Xóa bỏ',
+                        clear_field_highlight: 'Điểm nổi bật rõ ràng',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: 'Xóa loại',
                 },
             },
         },
@@ -277,7 +278,6 @@ export const vi: LanguageTranslation = {
             custom_type_highlight_tooltip:
                 'Highlighting "{{typeName}}" - Click to clear',
             highlight_overlapping_tables: 'Làm nổi bật các bảng chồng chéo',
-            // TODO: Translate
             filter: 'Filter Tables',
         },
 
@@ -324,6 +324,7 @@ export const vi: LanguageTranslation = {
                 tables_count: 'Số bảng',
             },
             cancel: 'Hủy',
+            start_new: 'Bắt đầu với sơ đồ mới',
             open: 'Mở',
 
             diagram_actions: {
@@ -393,7 +394,6 @@ export const vi: LanguageTranslation = {
             scale_4x: '4x',
             cancel: 'Hủy',
             export: 'Xuất',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -455,7 +455,6 @@ export const vi: LanguageTranslation = {
                     'Sơ đồ ở dạng JSON không hợp lệ. Vui lòng kiểm tra JSON và thử lại. Bạn cần trợ giúp? support@chartdb.io',
             },
         },
-        // TODO: Translate
         import_dbml_dialog: {
             example_title: 'Import Example DBML',
             title: 'Import DBML',
@@ -480,7 +479,6 @@ export const vi: LanguageTranslation = {
             new_table: 'Tạo bảng mới',
             new_view: 'Chế độ xem Mới',
             new_relationship: 'Tạo quan hệ mới',
-            // TODO: Translate
             new_area: 'New Area',
         },
 
@@ -488,7 +486,7 @@ export const vi: LanguageTranslation = {
             edit_table: 'Sửa bảng',
             duplicate_table: 'Nhân đôi bảng',
             delete_table: 'Xóa bảng',
-            add_relationship: 'Add Relationship', // TODO: Translate
+            add_relationship: 'Thêm mối quan hệ',
         },
 
         snap_to_grid_tooltip: 'Căn lưới (Giữ phím {{key}})',

--- a/src/i18n/locales/zh_CN.ts
+++ b/src/i18n/locales/zh_CN.ts
@@ -41,9 +41,8 @@ export const zh_CN: LanguageTranslation = {
                 theme: '主题',
                 show_dependencies: '展示依赖',
                 hide_dependencies: '隐藏依赖',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: '显示小地图',
+                hide_minimap: '隐藏小地图',
             },
             backup: {
                 backup: '备份',
@@ -111,6 +110,12 @@ export const zh_CN: LanguageTranslation = {
         copy_to_clipboard: '复制到剪切板',
         copied: '复制了！',
 
+        share_table_dialog: {
+            title: '共享表',
+            description: '复制下面的链接以共享此表。',
+            close: '关闭',
+        },
+
         side_panel: {
             view_all_options: '查看所有选项...',
             tables_section: {
@@ -119,12 +124,10 @@ export const zh_CN: LanguageTranslation = {
                 add_view: '添加视图',
                 filter: '筛选',
                 collapse: '全部折叠',
-                // TODO: Translate
-                clear: 'Clear Filter',
-                no_results: 'No tables found matching your filter.',
-                // TODO: Translate
-                show_list: 'Show Table List',
-                show_dbml: 'Show DBML Editor',
+                clear: '清除过滤器',
+                no_results: '找不到与您的过滤器匹配的桌子。',
+                show_list: '显示表列表',
+                show_dbml: '显示DBML编辑器',
 
                 table: {
                     fields: '字段',
@@ -146,10 +149,8 @@ export const zh_CN: LanguageTranslation = {
                         comments: '注释',
                         no_comments: '空',
                         delete_field: '删除字段',
-                        // TODO: Translate
                         default_value: 'Default Value',
                         no_default: 'No default',
-                        // TODO: Translate
                         character_length: 'Max Length',
                         precision: '精度',
                         scale: '小数位',
@@ -166,7 +167,7 @@ export const zh_CN: LanguageTranslation = {
                         change_schema: '更改模式',
                         add_field: '添加字段',
                         add_index: '添加索引',
-                        duplicate_table: 'Duplicate Table', // TODO: Translate
+                        duplicate_table: '复制表',
                         delete_table: '删除表',
                     },
                 },
@@ -208,55 +209,51 @@ export const zh_CN: LanguageTranslation = {
                     description: '创建关系以开始',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
+                areas: '区域',
+                add_area: '添加区域',
+                filter: '筛选',
+                clear: '清除过滤器',
+                no_results: '没有发现与您的过滤器相匹配的区域。',
 
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: '区域行动',
+                        edit_name: '编辑名称',
+                        delete_area: '删除区域',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: '没有区域',
+                    description: '创建一个开始的区域',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: '自定义类型',
+                filter: '筛选',
+                clear: '清除过滤器',
+                no_results: '没有发现与您的过滤器匹配的自定义类型。',
                 empty_state: {
-                    title: 'No custom types',
-                    description:
-                        'Custom types will appear here when they are available in your database',
+                    title: '没有自定义类型',
+                    description: '自定义类型将在您的数据库中可用时出现在此处',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: '种类',
+                    enum_values: '枚举值',
+                    composite_fields: '字段',
+                    no_fields: '没有定义字段',
                     no_values: '没有定义枚举值',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: '字段名称',
+                    field_type_placeholder: '选择类型',
+                    add_field: '添加字段',
+                    no_fields_tooltip: '该自定义类型没有定义的字段',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: '动作',
+                        highlight_fields: '突出显示字段',
+                        delete_custom_type: '删除',
+                        clear_field_highlight: '清晰的亮点',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: '删除类型',
                 },
             },
         },
@@ -274,7 +271,6 @@ export const zh_CN: LanguageTranslation = {
             custom_type_highlight_tooltip:
                 'Highlighting "{{typeName}}" - Click to clear',
             highlight_overlapping_tables: '突出显示重叠的表',
-            // TODO: Translate
             filter: 'Filter Tables',
         },
 
@@ -296,7 +292,6 @@ export const zh_CN: LanguageTranslation = {
                     button_text: 'SSMS 说明',
                     title: '说明',
                     step_1: '前往 工具 > 选项 > 查询结果 > SQL Server。',
-                    // TODO: Add translations
                     step_2: '如果您使用“Result to Grid”功能，请将非 XML 数据的最大提取字符数更改为 9999999。',
                 },
                 instructions_link: '需要帮助？看看如何操作',
@@ -321,6 +316,7 @@ export const zh_CN: LanguageTranslation = {
                 tables_count: '表数量',
             },
             cancel: '取消',
+            start_new: '从新图表开始',
             open: '打开',
 
             diagram_actions: {
@@ -390,7 +386,6 @@ export const zh_CN: LanguageTranslation = {
             scale_4x: '4x',
             cancel: '取消',
             export: '导出',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -431,7 +426,6 @@ export const zh_CN: LanguageTranslation = {
             format_json: 'JSON',
             cancel: '取消',
             export: '导出',
-            // TODO: translate
             error: {
                 title: 'Error exporting diagram',
                 description:
@@ -450,7 +444,6 @@ export const zh_CN: LanguageTranslation = {
                     '关系图 JSON 无效，请检查 JSON 后重试。需要帮助？ 联系 support@chartdb.io',
             },
         },
-        // TODO: Translate
         import_dbml_dialog: {
             example_title: 'Import Example DBML',
             title: 'Import DBML',
@@ -475,15 +468,14 @@ export const zh_CN: LanguageTranslation = {
             new_table: '新建表',
             new_view: '新建视图',
             new_relationship: '新建关系',
-            // TODO: Translate
             new_area: 'New Area',
         },
 
         table_node_context_menu: {
             edit_table: '编辑表',
-            duplicate_table: 'Duplicate Table', // TODO: Translate
+            duplicate_table: '复制表',
             delete_table: '删除表',
-            add_relationship: 'Add Relationship', // TODO: Translate
+            add_relationship: '添加关系',
         },
 
         snap_to_grid_tooltip: '对齐到网格（按住 {{key}}）',

--- a/src/i18n/locales/zh_TW.ts
+++ b/src/i18n/locales/zh_TW.ts
@@ -41,9 +41,8 @@ export const zh_TW: LanguageTranslation = {
                 theme: '主題',
                 show_dependencies: '顯示相依性',
                 hide_dependencies: '隱藏相依性',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: '顯示小地圖',
+                hide_minimap: '隱藏小地圖',
             },
             backup: {
                 backup: '備份',
@@ -111,6 +110,12 @@ export const zh_TW: LanguageTranslation = {
         copy_to_clipboard: '複製到剪貼簿',
         copied: '已複製！',
 
+        share_table_dialog: {
+            title: '共享表',
+            description: '複製下面的鏈接以共享此表。',
+            close: '關閉',
+        },
+
         side_panel: {
             view_all_options: '顯示所有選項...',
             tables_section: {
@@ -119,12 +124,10 @@ export const zh_TW: LanguageTranslation = {
                 add_view: '新增檢視',
                 filter: '篩選',
                 collapse: '全部摺疊',
-                // TODO: Translate
-                clear: 'Clear Filter',
-                no_results: 'No tables found matching your filter.',
-                // TODO: Translate
-                show_list: 'Show Table List',
-                show_dbml: 'Show DBML Editor',
+                clear: '清除過濾器',
+                no_results: '找不到與您的過濾器匹配的桌子。',
+                show_list: '顯示表列表',
+                show_dbml: '顯示DBML編輯器',
 
                 table: {
                     fields: '欄位',
@@ -146,10 +149,8 @@ export const zh_TW: LanguageTranslation = {
                         comments: '註解',
                         no_comments: '無註解',
                         delete_field: '刪除欄位',
-                        // TODO: Translate
                         default_value: 'Default Value',
                         no_default: 'No default',
-                        // TODO: Translate
                         character_length: 'Max Length',
                         precision: '精度',
                         scale: '小數位',
@@ -166,7 +167,7 @@ export const zh_TW: LanguageTranslation = {
                         change_schema: '變更 Schema',
                         add_field: '新增欄位',
                         add_index: '新增索引',
-                        duplicate_table: 'Duplicate Table', // TODO: Translate
+                        duplicate_table: '複製表',
                         delete_table: '刪除表格',
                     },
                 },
@@ -208,55 +209,51 @@ export const zh_TW: LanguageTranslation = {
                     description: '請建立關聯以開始',
                 },
             },
-
-            // TODO: Translate
             areas_section: {
-                areas: 'Areas',
-                add_area: 'Add Area',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No areas found matching your filter.',
+                areas: '區域',
+                add_area: '添加區域',
+                filter: '篩選',
+                clear: '清除過濾器',
+                no_results: '沒有發現與您的過濾器相匹配的區域。',
 
                 area: {
                     area_actions: {
-                        title: 'Area Actions',
-                        edit_name: 'Edit Name',
-                        delete_area: 'Delete Area',
+                        title: '區域行動',
+                        edit_name: '編輯名稱',
+                        delete_area: '刪除區域',
                     },
                 },
                 empty_state: {
-                    title: 'No areas',
-                    description: 'Create an area to get started',
+                    title: '沒有區域',
+                    description: '創建一個開始的區域',
                 },
             },
-            // TODO: Translate
             custom_types_section: {
-                custom_types: 'Custom Types',
-                filter: 'Filter',
-                clear: 'Clear Filter',
-                no_results: 'No custom types found matching your filter.',
+                custom_types: '自定義類型',
+                filter: '篩選',
+                clear: '清除過濾器',
+                no_results: '沒有發現與您的過濾器匹配的自定義類型。',
                 empty_state: {
-                    title: 'No custom types',
-                    description:
-                        'Custom types will appear here when they are available in your database',
+                    title: '沒有自定義類型',
+                    description: '自定義類型將在您的數據庫中可用時出現在此處',
                 },
                 custom_type: {
-                    kind: 'Kind',
-                    enum_values: 'Enum Values',
-                    composite_fields: 'Fields',
-                    no_fields: 'No fields defined',
+                    kind: '種類',
+                    enum_values: '枚舉值',
+                    composite_fields: '字段',
+                    no_fields: '沒有定義字段',
                     no_values: '沒有定義列舉值',
-                    field_name_placeholder: 'Field name',
-                    field_type_placeholder: 'Select type',
-                    add_field: 'Add Field',
-                    no_fields_tooltip: 'No fields defined for this custom type',
+                    field_name_placeholder: '字段名稱',
+                    field_type_placeholder: '選擇類型',
+                    add_field: '添加字段',
+                    no_fields_tooltip: '該自定義類型沒有定義的字段',
                     custom_type_actions: {
-                        title: 'Actions',
-                        highlight_fields: 'Highlight Fields',
-                        delete_custom_type: 'Delete',
-                        clear_field_highlight: 'Clear Highlight',
+                        title: '動作',
+                        highlight_fields: '突出顯示字段',
+                        delete_custom_type: '刪除',
+                        clear_field_highlight: '清晰的亮點',
                     },
-                    delete_custom_type: 'Delete Type',
+                    delete_custom_type: '刪除類型',
                 },
             },
         },
@@ -274,7 +271,6 @@ export const zh_TW: LanguageTranslation = {
             custom_type_highlight_tooltip:
                 'Highlighting "{{typeName}}" - Click to clear',
             highlight_overlapping_tables: '突出顯示重疊表格',
-            // TODO: Translate
             filter: 'Filter Tables',
         },
 
@@ -320,6 +316,7 @@ export const zh_TW: LanguageTranslation = {
                 tables_count: '表格數',
             },
             cancel: '取消',
+            start_new: '從新圖表開始',
             open: '開啟',
 
             diagram_actions: {
@@ -389,7 +386,6 @@ export const zh_TW: LanguageTranslation = {
             scale_4x: '4x',
             cancel: '取消',
             export: '匯出',
-            // TODO: Translate
             advanced_options: 'Advanced Options',
             pattern: 'Include background pattern',
             pattern_description: 'Add subtle grid pattern to background.',
@@ -431,7 +427,6 @@ export const zh_TW: LanguageTranslation = {
             format_json: 'JSON',
             cancel: '取消',
             export: '匯出',
-            // TODO: Translate
             error: {
                 title: 'Error exporting diagram',
                 description:
@@ -450,7 +445,6 @@ export const zh_TW: LanguageTranslation = {
                     '圖表的 JSON 無效。請檢查 JSON 並再試一次。如需幫助，請聯繫 support@chartdb.io',
             },
         },
-        // TODO: Translate
         import_dbml_dialog: {
             example_title: 'Import Example DBML',
             title: 'Import DBML',
@@ -475,15 +469,14 @@ export const zh_TW: LanguageTranslation = {
             new_table: '新建表格',
             new_view: '新檢視',
             new_relationship: '新建關聯',
-            // TODO: Translate
             new_area: 'New Area',
         },
 
         table_node_context_menu: {
             edit_table: '編輯表格',
-            duplicate_table: 'Duplicate Table', // TODO: Translate
+            duplicate_table: '複製表',
             delete_table: '刪除表格',
-            add_relationship: 'Add Relationship', // TODO: Translate
+            add_relationship: '添加關係',
         },
 
         snap_to_grid_tooltip: '對齊網格（按住 {{key}}）',

--- a/src/lib/data/data-types/data-types.ts
+++ b/src/lib/data/data-types/data-types.ts
@@ -12,6 +12,8 @@ import { oracleDataTypes } from './oracle-data-types';
 export interface DataType {
     id: string;
     name: string;
+    usageLevel?: 1 | 2;
+    fieldAttributes?: FieldAttributes;
 }
 
 export interface FieldAttributeRange {
@@ -20,7 +22,7 @@ export interface FieldAttributeRange {
     default: number;
 }
 
-interface FieldAttributes {
+export interface FieldAttributes {
     hasCharMaxLength?: boolean;
     hasCharMaxLengthOption?: boolean;
     precision?: FieldAttributeRange;
@@ -28,15 +30,36 @@ interface FieldAttributes {
     maxLength?: number;
 }
 
-export interface DataTypeData extends DataType {
-    usageLevel?: 1 | 2; // Level 1 is most common, Level 2 is second most common
-    fieldAttributes?: FieldAttributes;
-}
+export interface DataTypeData extends DataType {}
 
-export const dataTypeSchema: z.ZodType<DataType> = z.object({
-    id: z.string(),
-    name: z.string(),
-});
+export const dataTypeSchema: z.ZodType<DataType> = z
+    .object({
+        id: z.string(),
+        name: z.string(),
+        usageLevel: z.union([z.literal(1), z.literal(2)]).optional(),
+        fieldAttributes: z
+            .object({
+                hasCharMaxLength: z.boolean().optional(),
+                hasCharMaxLengthOption: z.boolean().optional(),
+                precision: z
+                    .object({
+                        max: z.number(),
+                        min: z.number(),
+                        default: z.number(),
+                    })
+                    .optional(),
+                scale: z
+                    .object({
+                        max: z.number(),
+                        min: z.number(),
+                        default: z.number(),
+                    })
+                    .optional(),
+                maxLength: z.number().optional(),
+            })
+            .optional(),
+    })
+    .passthrough();
 
 export const dataTypeMap: Record<DatabaseType, readonly DataTypeData[]> = {
     [DatabaseType.GENERIC]: genericDataTypes,

--- a/src/lib/export-import-utils.ts
+++ b/src/lib/export-import-utils.ts
@@ -27,6 +27,25 @@ export const diagramToJSONOutput = (diagram: Diagram): string => {
     return JSON.stringify(clonedDiagram, null, 2);
 };
 
+export const diagramToStorageJSON = (diagram: Diagram): Diagram => ({
+    ...diagram,
+    tables: (diagram.tables ?? []).map((table) => ({
+        ...table,
+        x: table.x ?? 0,
+        y: table.y ?? 0,
+    })),
+    relationships: diagram.relationships ?? [],
+    dependencies: diagram.dependencies ?? [],
+    areas: (diagram.areas ?? []).map((area) => ({
+        ...area,
+        x: area.x ?? 0,
+        y: area.y ?? 0,
+        width: area.width ?? 0,
+        height: area.height ?? 0,
+    })),
+    customTypes: diagram.customTypes ?? [],
+});
+
 export const diagramFromJSONInput = (json: string): Diagram => {
     const loadedDiagram = JSON.parse(json);
 

--- a/src/pages/editor-page/canvas/canvas-context-menu.tsx
+++ b/src/pages/editor-page/canvas/canvas-context-menu.tsx
@@ -127,7 +127,7 @@ export const CanvasContextMenu: React.FC<React.PropsWithChildren> = ({
 
     return (
         <ContextMenu>
-            <ContextMenuTrigger disabled={readonly}>
+            <ContextMenuTrigger disabled={readonly} asChild>
                 {children}
             </ContextMenuTrigger>
             <ContextMenuContent>

--- a/src/pages/editor-page/canvas/canvas-filter/canvas-filter.tsx
+++ b/src/pages/editor-page/canvas/canvas-filter/canvas-filter.tsx
@@ -28,7 +28,6 @@ import { FilterItemActions } from './filter-item-actions';
 import { databasesWithSchemas } from '@/lib/domain';
 import { getOperatingSystem } from '@/lib/utils';
 import { useLocalConfig } from '@/hooks/use-local-config';
-import { useDiff } from '@/context/diff-context/use-diff';
 
 export interface CanvasFilterProps {
     onClose: () => void;
@@ -37,7 +36,6 @@ export interface CanvasFilterProps {
 export const CanvasFilter: React.FC<CanvasFilterProps> = ({ onClose }) => {
     const { t } = useTranslation();
     const { tables, databaseType, areas } = useChartDB();
-    const { checkIfNewTable } = useDiff();
     const {
         filter,
         toggleSchemaFilter,
@@ -60,14 +58,13 @@ export const CanvasFilter: React.FC<CanvasFilterProps> = ({ onClose }) => {
         () =>
             tables
                 .filter((table) => (showDBViews ? true : !table.isView))
-                .filter((table) => !checkIfNewTable({ tableId: table.id }))
                 .map((table) => ({
                     id: table.id,
                     name: table.name,
                     schema: table.schema,
                     parentAreaId: table.parentAreaId,
                 })),
-        [tables, showDBViews, checkIfNewTable]
+        [tables, showDBViews]
     );
 
     const databaseWithSchemas = useMemo(

--- a/src/pages/editor-page/editor-desktop-layout.tsx
+++ b/src/pages/editor-page/editor-desktop-layout.tsx
@@ -15,11 +15,25 @@ import { TopNavbar } from './top-navbar/top-navbar';
 
 export interface EditorDesktopLayoutProps {
     initialDiagram?: Diagram;
+    clean?: boolean;
+    tableId?: string;
 }
 export const EditorDesktopLayout: React.FC<EditorDesktopLayoutProps> = ({
     initialDiagram,
+    clean,
+    tableId,
 }) => {
     const { isSidePanelShowed } = useLayout();
+
+    if (clean) {
+        return (
+            <Canvas
+                initialTables={initialDiagram?.tables ?? []}
+                clean
+                tableId={tableId}
+            />
+        );
+    }
 
     return (
         <>
@@ -46,7 +60,10 @@ export const EditorDesktopLayout: React.FC<EditorDesktopLayoutProps> = ({
                         className={!isSidePanelShowed ? 'hidden' : ''}
                     />
                     <ResizablePanel defaultSize={75}>
-                        <Canvas initialTables={initialDiagram?.tables ?? []} />
+                        <Canvas
+                            initialTables={initialDiagram?.tables ?? []}
+                            tableId={tableId}
+                        />
                     </ResizablePanel>
                 </ResizablePanelGroup>
             </SidebarProvider>

--- a/src/pages/editor-page/editor-mobile-layout.tsx
+++ b/src/pages/editor-page/editor-mobile-layout.tsx
@@ -17,11 +17,24 @@ import { EditorSidebar } from './editor-sidebar/editor-sidebar';
 
 export interface EditorMobileLayoutProps {
     initialDiagram?: Diagram;
+    clean?: boolean;
+    tableId?: string;
 }
 export const EditorMobileLayout: React.FC<EditorMobileLayoutProps> = ({
     initialDiagram,
+    clean,
+    tableId,
 }) => {
     const { isSidePanelShowed, hideSidePanel } = useLayout();
+    if (clean) {
+        return (
+            <Canvas
+                initialTables={initialDiagram?.tables ?? []}
+                clean
+                tableId={tableId}
+            />
+        );
+    }
     return (
         <>
             <SidebarProvider
@@ -46,7 +59,10 @@ export const EditorMobileLayout: React.FC<EditorMobileLayoutProps> = ({
                         <SidePanel data-vaul-no-drag />
                     </DrawerContent>
                 </Drawer>
-                <Canvas initialTables={initialDiagram?.tables ?? []} />
+                <Canvas
+                    initialTables={initialDiagram?.tables ?? []}
+                    tableId={tableId}
+                />
             </SidebarProvider>
         </>
     );

--- a/src/pages/editor-page/editor-page.tsx
+++ b/src/pages/editor-page/editor-page.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useChartDB } from '@/hooks/use-chartdb';
 import { useDialog } from '@/hooks/use-dialog';
 import { Toaster } from '@/components/toast/toaster';
@@ -38,7 +39,15 @@ export const EditorMobileLayoutLazy = React.lazy(
     () => import('./editor-mobile-layout')
 );
 
-const EditorPageComponent: React.FC = () => {
+interface EditorPageComponentProps {
+    clean?: boolean;
+    tableId?: string;
+}
+
+const EditorPageComponent: React.FC<EditorPageComponentProps> = ({
+    clean = false,
+    tableId,
+}) => {
     const { diagramName, currentDiagram } = useChartDB();
     const { openStarUsDialog } = useDialog();
     const { isMd: isDesktop } = useBreakpoint('md');
@@ -47,7 +56,7 @@ const EditorPageComponent: React.FC = () => {
     const { initialDiagram } = useDiagramLoader();
 
     useEffect(() => {
-        if (HIDE_CHARTDB_CLOUD) {
+        if (clean || HIDE_CHARTDB_CLOUD) {
             return;
         }
 
@@ -64,6 +73,7 @@ const EditorPageComponent: React.FC = () => {
             setTimeout(openStarUsDialog, OPEN_STAR_US_AFTER_SECONDS * 1000);
         }
     }, [
+        clean,
         currentDiagram?.id,
         githubRepoOpened,
         openStarUsDialog,
@@ -86,7 +96,7 @@ const EditorPageComponent: React.FC = () => {
                 <Suspense
                     fallback={
                         <>
-                            <TopNavbarMock />
+                            {!clean && <TopNavbarMock />}
                             <div className="flex flex-1 items-center justify-center">
                                 <Spinner
                                     size={isDesktop ? 'large' : 'medium'}
@@ -98,53 +108,72 @@ const EditorPageComponent: React.FC = () => {
                     {isDesktop ? (
                         <EditorDesktopLayoutLazy
                             initialDiagram={initialDiagram}
+                            clean={clean}
+                            tableId={tableId}
                         />
                     ) : (
                         <EditorMobileLayoutLazy
                             initialDiagram={initialDiagram}
+                            clean={clean}
+                            tableId={tableId}
                         />
                     )}
                 </Suspense>
             </section>
-            <Toaster />
+            {!clean && <Toaster />}
         </>
     );
 };
 
-export const EditorPage: React.FC = () => (
-    <LocalConfigProvider>
-        <ThemeProvider>
-            <FullScreenLoaderProvider>
-                <LayoutProvider>
-                    <StorageProvider>
-                        <ConfigProvider>
-                            <RedoUndoStackProvider>
-                                <DiffProvider>
-                                    <ChartDBProvider>
-                                        <DiagramFilterProvider>
-                                            <HistoryProvider>
-                                                <ReactFlowProvider>
-                                                    <CanvasProvider>
-                                                        <ExportImageProvider>
-                                                            <AlertProvider>
-                                                                <DialogProvider>
-                                                                    <KeyboardShortcutsProvider>
-                                                                        <EditorPageComponent />
-                                                                    </KeyboardShortcutsProvider>
-                                                                </DialogProvider>
-                                                            </AlertProvider>
-                                                        </ExportImageProvider>
-                                                    </CanvasProvider>
-                                                </ReactFlowProvider>
-                                            </HistoryProvider>
-                                        </DiagramFilterProvider>
-                                    </ChartDBProvider>
-                                </DiffProvider>
-                            </RedoUndoStackProvider>
-                        </ConfigProvider>
-                    </StorageProvider>
-                </LayoutProvider>
-            </FullScreenLoaderProvider>
-        </ThemeProvider>
-    </LocalConfigProvider>
-);
+export const EditorPage: React.FC = () => {
+    const [searchParams] = useSearchParams();
+    const clean = searchParams.get('clean') === 'true';
+    const tableId = clean
+        ? (searchParams.get('table') ?? undefined)
+        : undefined;
+
+    return (
+        <LocalConfigProvider>
+            <ThemeProvider>
+                <FullScreenLoaderProvider>
+                    <LayoutProvider>
+                        <StorageProvider>
+                            <ConfigProvider>
+                                <RedoUndoStackProvider>
+                                    <DiffProvider>
+                                        <ChartDBProvider readonly={clean}>
+                                            <DiagramFilterProvider>
+                                                <HistoryProvider>
+                                                    <ReactFlowProvider>
+                                                        <CanvasProvider>
+                                                            <ExportImageProvider>
+                                                                <AlertProvider>
+                                                                    <DialogProvider>
+                                                                        <KeyboardShortcutsProvider>
+                                                                            <EditorPageComponent
+                                                                                clean={
+                                                                                    clean
+                                                                                }
+                                                                                tableId={
+                                                                                    tableId
+                                                                                }
+                                                                            />
+                                                                        </KeyboardShortcutsProvider>
+                                                                    </DialogProvider>
+                                                                </AlertProvider>
+                                                            </ExportImageProvider>
+                                                        </CanvasProvider>
+                                                    </ReactFlowProvider>
+                                                </HistoryProvider>
+                                            </DiagramFilterProvider>
+                                        </ChartDBProvider>
+                                    </DiffProvider>
+                                </RedoUndoStackProvider>
+                            </ConfigProvider>
+                        </StorageProvider>
+                    </LayoutProvider>
+                </FullScreenLoaderProvider>
+            </ThemeProvider>
+        </LocalConfigProvider>
+    );
+};

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/table-list-item-header.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/table-list-item-header.tsx
@@ -10,6 +10,7 @@ import {
     Check,
     Group,
     Copy,
+    Share2,
 } from 'lucide-react';
 import { ListItemHeaderButton } from '@/pages/editor-page/side-panel/list-item-header-button/list-item-header-button';
 import type { DBTable } from '@/lib/domain/db-table';
@@ -58,7 +59,7 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
         readonly,
     } = useChartDB();
     const { schemasDisplayed } = useDiagramFilter();
-    const { openTableSchemaDialog } = useDialog();
+    const { openTableSchemaDialog, openShareTableDialog } = useDialog();
     const { t } = useTranslation();
     const { focusOnTable } = useFocusOn();
     const [editMode, setEditMode] = React.useState(false);
@@ -95,6 +96,14 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
             focusOnTable(table.id);
         },
         [focusOnTable, table.id]
+    );
+
+    const handleShareTable = useCallback(
+        (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+            event.stopPropagation();
+            openShareTableDialog({ tableId: table.id });
+        },
+        [openShareTableDialog, table.id]
     );
 
     const deleteTableHandler = useCallback(() => {
@@ -304,6 +313,9 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
                     <>
                         {!readonly ? <div>{renderDropDownMenu()}</div> : null}
                         <div className="flex flex-row-reverse md:hidden md:group-hover:flex">
+                            <ListItemHeaderButton onClick={handleShareTable}>
+                                <Share2 />
+                            </ListItemHeaderButton>
                             {!readonly ? (
                                 <ListItemHeaderButton onClick={enterEditMode}>
                                     <Pencil />

--- a/src/pages/editor-page/top-navbar/menu/menu.tsx
+++ b/src/pages/editor-page/top-navbar/menu/menu.tsx
@@ -13,6 +13,7 @@ import {
     MenubarTrigger,
 } from '@/components/menubar/menubar';
 import { useChartDB } from '@/hooks/use-chartdb';
+import { useSaveDiagram } from '@/hooks/use-save-diagram';
 import { useDialog } from '@/hooks/use-dialog';
 import { useExportImage } from '@/hooks/use-export-image';
 import { databaseTypeToLabelMap } from '@/lib/databases';
@@ -32,12 +33,8 @@ import { useAlert } from '@/context/alert-context/alert-context';
 export interface MenuProps {}
 
 export const Menu: React.FC<MenuProps> = () => {
-    const {
-        clearDiagramData,
-        deleteDiagram,
-        updateDiagramUpdatedAt,
-        databaseType,
-    } = useChartDB();
+    const { clearDiagramData, deleteDiagram, databaseType } = useChartDB();
+    const { saveDiagram } = useSaveDiagram();
     const {
         openCreateDiagramDialog,
         openOpenDiagramDialog,
@@ -166,7 +163,7 @@ export const Menu: React.FC<MenuProps> = () => {
                             }
                         </MenubarShortcut>
                     </MenubarItem>
-                    <MenubarItem onClick={updateDiagramUpdatedAt}>
+                    <MenubarItem onClick={saveDiagram}>
                         {t('menu.actions.save')}
                         <MenubarShortcut>
                             {


### PR DESCRIPTION
**This is an improved version of pr #894** 

This PR adds functionality to store and load diagrams from a mounted Docker volume. This makes it much easier to work across multiple devices and to share diagrams with others.

All files are stored under /data. To use this, you need to mount either a local folder or a Docker volume to that path. The files are stored in the same format as the exported .json files, so they are fully compatible. You can also place previously saved .json files into /data and start using them directly in ChartDB.

In this implementation, I removed the option to store diagrams in the browser’s local storage. I realize this might conflict with the maintainers’ philosophy, so I’m happy to discuss alternatives or adjustments if needed.

For anyone who just wants to try it out quickly, I’ve also published a ready-to-use Docker image with the volume mounting feature in my personal repository.


**More features:**

- added start with new diagram button to open diagram dialog
- added `clean=true` parameter option to diagram url for embedding
- added a `table=<table id>` parameter in addition to the `clean` parameter. this is to show a single table in clean mode instead of the whole diagram (e.g. for documentation)
- added a share button to each table with a dialog to copy the shareable url of a single table
- added translations