### PR TITLE
feat: implement reusable click-outside hook for edit fields

### DIFF
--- a/src/hooks/use-click-outside.ts
+++ b/src/hooks/use-click-outside.ts
@@ -1,0 +1,50 @@
+import { useEffect, useCallback, type RefObject } from 'react';
+
+/**
+ * Custom hook that handles click outside detection with capture phase
+ * to work properly with React Flow canvas and other event-stopping elements
+ */
+export function useClickOutside(
+    ref: RefObject<HTMLElement>,
+    handler: () => void,
+    isActive = true
+) {
+    useEffect(() => {
+        if (!isActive) return;
+
+        const handleClickOutside = (event: MouseEvent) => {
+            if (ref.current && !ref.current.contains(event.target as Node)) {
+                handler();
+            }
+        };
+
+        // Use capture phase to catch events before React Flow or other libraries can stop them
+        document.addEventListener('mousedown', handleClickOutside, true);
+
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside, true);
+        };
+    }, [ref, handler, isActive]);
+}
+
+/**
+ * Specialized version of useClickOutside for edit mode inputs
+ * Adds a small delay to prevent race conditions with blur events
+ */
+export function useEditClickOutside(
+    inputRef: RefObject<HTMLElement>,
+    editMode: boolean,
+    onSave: () => void,
+    delay = 100
+) {
+    const handleClickOutside = useCallback(() => {
+        if (editMode) {
+            // Small delay to ensure any pending state updates are processed
+            setTimeout(() => {
+                onSave();
+            }, delay);
+        }
+    }, [editMode, onSave, delay]);
+
+    useClickOutside(inputRef, handleClickOutside, editMode);
+}

--- a/src/pages/editor-page/canvas/area-node/area-node-context-menu.tsx
+++ b/src/pages/editor-page/canvas/area-node/area-node-context-menu.tsx
@@ -1,0 +1,54 @@
+import {
+    ContextMenu,
+    ContextMenuContent,
+    ContextMenuItem,
+    ContextMenuTrigger,
+} from '@/components/context-menu/context-menu';
+import { useBreakpoint } from '@/hooks/use-breakpoint';
+import { useChartDB } from '@/hooks/use-chartdb';
+import type { Area } from '@/lib/domain/area';
+import { Pencil, Trash2 } from 'lucide-react';
+import React, { useCallback } from 'react';
+
+export interface AreaNodeContextMenuProps {
+    area: Area;
+    onEditName?: () => void;
+}
+
+export const AreaNodeContextMenu: React.FC<
+    React.PropsWithChildren<AreaNodeContextMenuProps>
+> = ({ children, area, onEditName }) => {
+    const { removeArea, readonly } = useChartDB();
+    const { isMd: isDesktop } = useBreakpoint('md');
+
+    const removeAreaHandler = useCallback(() => {
+        removeArea(area.id);
+    }, [removeArea, area.id]);
+
+    if (!isDesktop || readonly) {
+        return <>{children}</>;
+    }
+    return (
+        <ContextMenu>
+            <ContextMenuTrigger>{children}</ContextMenuTrigger>
+            <ContextMenuContent>
+                {onEditName && (
+                    <ContextMenuItem
+                        onClick={onEditName}
+                        className="flex justify-between gap-3"
+                    >
+                        <span>Edit Area Name</span>
+                        <Pencil className="size-3.5" />
+                    </ContextMenuItem>
+                )}
+                <ContextMenuItem
+                    onClick={removeAreaHandler}
+                    className="flex justify-between gap-3"
+                >
+                    <span>Delete Area</span>
+                    <Trash2 className="size-3.5 text-red-700" />
+                </ContextMenuItem>
+            </ContextMenuContent>
+        </ContextMenu>
+    );
+};

--- a/src/pages/editor-page/canvas/area-node/area-node.tsx
+++ b/src/pages/editor-page/canvas/area-node/area-node.tsx
@@ -1,10 +1,11 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import type { NodeProps, Node } from '@xyflow/react';
 import { NodeResizer } from '@xyflow/react';
 import type { Area } from '@/lib/domain/area';
 import { useChartDB } from '@/hooks/use-chartdb';
 import { Input } from '@/components/input/input';
-import { useClickAway, useKeyPressEvent } from 'react-use';
+import { useEditClickOutside } from '@/hooks/use-click-outside';
+import { useKeyPressEvent } from 'react-use';
 import {
     Tooltip,
     TooltipContent,
@@ -12,9 +13,10 @@ import {
 } from '@/components/tooltip/tooltip';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
-import { Check, GripVertical } from 'lucide-react';
+import { Check, GripVertical, Pencil } from 'lucide-react';
 import { Button } from '@/components/button/button';
 import { useLayout } from '@/hooks/use-layout';
+import { AreaNodeContextMenu } from './area-node-context-menu';
 
 export type AreaNodeType = Node<
     {
@@ -35,12 +37,11 @@ export const AreaNode: React.FC<NodeProps<AreaNodeType>> = React.memo(
         const focused = !!selected && !dragging;
 
         const editAreaName = useCallback(() => {
-            if (!editMode) return;
             if (areaName.trim()) {
                 updateArea(area.id, { name: areaName.trim() });
             }
             setEditMode(false);
-        }, [areaName, area.id, updateArea, editMode]);
+        }, [areaName, area.id, updateArea]);
 
         const abortEdit = useCallback(() => {
             setEditMode(false);
@@ -52,89 +53,119 @@ export const AreaNode: React.FC<NodeProps<AreaNodeType>> = React.memo(
             openAreaFromSidebar(area.id);
         }, [selectSidebarSection, openAreaFromSidebar, area.id]);
 
-        useClickAway(inputRef, editAreaName);
+        // Handle click outside to save and exit edit mode
+        useEditClickOutside(inputRef, editMode, editAreaName);
         useKeyPressEvent('Enter', editAreaName);
         useKeyPressEvent('Escape', abortEdit);
 
-        const enterEditMode = (e: React.MouseEvent) => {
-            e.stopPropagation();
-            setEditMode(true);
-        };
+        const enterEditMode = useCallback(
+            (e?: React.MouseEvent) => {
+                e?.stopPropagation();
+                setAreaName(area.name);
+                setEditMode(true);
+            },
+            [area.name]
+        );
+
+        useEffect(() => {
+            if (editMode) {
+                // Small delay to ensure the input is rendered
+                const timeoutId = setTimeout(() => {
+                    if (inputRef.current) {
+                        inputRef.current.focus();
+                        inputRef.current.select();
+                    }
+                }, 50);
+
+                return () => clearTimeout(timeoutId);
+            }
+        }, [editMode]);
 
         return (
-            <div
-                className={cn(
-                    'flex h-full flex-col rounded-md border-2 shadow-sm',
-                    selected ? 'border-pink-600' : 'border-transparent'
-                )}
-                style={{
-                    backgroundColor: `${area.color}15`,
-                    borderColor: selected ? undefined : area.color,
-                }}
-                onClick={(e) => {
-                    if (e.detail === 2) {
-                        openAreaInEditor();
-                    }
-                }}
-            >
-                {!readonly ? (
-                    <NodeResizer
-                        isVisible={focused}
-                        lineClassName="!border-4 !border-transparent"
-                        handleClassName="!h-[10px] !w-[10px] !rounded-full !bg-pink-600"
-                        minHeight={100}
-                        minWidth={100}
-                    />
-                ) : null}
-                <div className="group flex h-8 items-center justify-between rounded-t-md px-2">
-                    <div className="flex w-full items-center gap-1">
-                        <GripVertical className="size-4 shrink-0 text-slate-700 opacity-60 dark:text-slate-300" />
+            <AreaNodeContextMenu area={area} onEditName={enterEditMode}>
+                <div
+                    className={cn(
+                        'flex h-full flex-col rounded-md border-2 shadow-sm',
+                        selected ? 'border-pink-600' : 'border-transparent'
+                    )}
+                    style={{
+                        backgroundColor: `${area.color}15`,
+                        borderColor: selected ? undefined : area.color,
+                    }}
+                    onClick={(e) => {
+                        if (e.detail === 2) {
+                            openAreaInEditor();
+                        }
+                    }}
+                >
+                    {!readonly ? (
+                        <NodeResizer
+                            isVisible={focused}
+                            lineClassName="!border-4 !border-transparent"
+                            handleClassName="!h-[10px] !w-[10px] !rounded-full !bg-pink-600"
+                            minHeight={100}
+                            minWidth={100}
+                        />
+                    ) : null}
+                    <div className="group flex h-8 items-center justify-between rounded-t-md px-2">
+                        <div className="flex w-full items-center gap-1">
+                            <GripVertical className="size-4 shrink-0 text-slate-700 opacity-60 dark:text-slate-300" />
 
-                        {editMode && !readonly ? (
-                            <div className="flex w-full items-center">
-                                <Input
-                                    ref={inputRef}
-                                    autoFocus
-                                    type="text"
-                                    placeholder={area.name}
-                                    value={areaName}
-                                    onClick={(e) => e.stopPropagation()}
-                                    onChange={(e) =>
-                                        setAreaName(e.target.value)
-                                    }
-                                    className="h-6 bg-white/70 focus-visible:ring-0 dark:bg-slate-900/70"
-                                />
+                            {editMode && !readonly ? (
+                                <div className="flex w-full items-center">
+                                    <Input
+                                        ref={inputRef}
+                                        autoFocus
+                                        type="text"
+                                        placeholder={area.name}
+                                        value={areaName}
+                                        onClick={(e) => e.stopPropagation()}
+                                        onChange={(e) =>
+                                            setAreaName(e.target.value)
+                                        }
+                                        className="h-6 bg-white/70 focus-visible:ring-0 dark:bg-slate-900/70"
+                                    />
+                                    <Button
+                                        variant="ghost"
+                                        className="ml-1 size-6 p-0 hover:bg-white/20"
+                                        onClick={editAreaName}
+                                    >
+                                        <Check className="size-3.5 text-slate-700 dark:text-slate-300" />
+                                    </Button>
+                                </div>
+                            ) : !readonly ? (
+                                <Tooltip>
+                                    <TooltipTrigger asChild>
+                                        <div
+                                            className="text-editable truncate px-1 py-0.5 text-base font-semibold text-slate-700 dark:text-slate-300"
+                                            onDoubleClick={enterEditMode}
+                                        >
+                                            {area.name}
+                                        </div>
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                        {t('tool_tips.double_click_to_edit')}
+                                    </TooltipContent>
+                                </Tooltip>
+                            ) : (
+                                <div className="truncate px-1 py-0.5 text-base font-semibold text-slate-700 dark:text-slate-300">
+                                    {area.name}
+                                </div>
+                            )}
+                            {!editMode && !readonly && (
                                 <Button
                                     variant="ghost"
-                                    className="ml-1 size-6 p-0 hover:bg-white/20"
-                                    onClick={editAreaName}
+                                    className="ml-auto size-5 p-0 opacity-0 transition-opacity hover:bg-white/20 group-hover:opacity-100"
+                                    onClick={enterEditMode}
                                 >
-                                    <Check className="size-3.5 text-slate-700 dark:text-slate-300" />
+                                    <Pencil className="size-3 text-slate-700 dark:text-slate-300" />
                                 </Button>
-                            </div>
-                        ) : !readonly ? (
-                            <Tooltip>
-                                <TooltipTrigger asChild>
-                                    <div
-                                        className="text-editable max-w-[200px] cursor-text truncate px-1 py-0.5 text-base font-semibold text-slate-700 dark:text-slate-300"
-                                        onDoubleClick={enterEditMode}
-                                    >
-                                        {area.name}
-                                    </div>
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                    {t('tool_tips.double_click_to_edit')}
-                                </TooltipContent>
-                            </Tooltip>
-                        ) : (
-                            <div className="truncate px-1 py-0.5 text-base font-semibold text-slate-700 dark:text-slate-300">
-                                {area.name}
-                            </div>
-                        )}
+                            )}
+                        </div>
                     </div>
+                    <div className="flex-1" />
                 </div>
-                <div className="flex-1" />
-            </div>
+            </AreaNodeContextMenu>
         );
     }
 );

--- a/src/pages/editor-page/canvas/table-node/table-edit-mode/table-edit-mode.tsx
+++ b/src/pages/editor-page/canvas/table-node/table-edit-mode/table-edit-mode.tsx
@@ -11,6 +11,7 @@ import { Separator } from '@/components/separator/separator';
 import { useChartDB } from '@/hooks/use-chartdb';
 import { useUpdateTable } from '@/hooks/use-update-table';
 import { useTranslation } from 'react-i18next';
+import { useClickOutside } from '@/hooks/use-click-outside';
 
 export interface TableEditModeProps {
     table: DBTable;
@@ -107,6 +108,9 @@ export const TableEditMode: React.FC<TableEditModeProps> = React.memo(
                 setFocusFieldId(field.id);
             }
         }, [createField, table.id]);
+
+        // Close edit mode when clicking outside
+        useClickOutside(containerRef, onClose, isVisible);
 
         const handleColorChange = useCallback(
             (newColor: string) => {

--- a/src/pages/editor-page/side-panel/refs-section/refs-list/relationship-list-item/relationship-list-item-header/relationship-list-item-header.tsx
+++ b/src/pages/editor-page/side-panel/refs-section/refs-list/relationship-list-item/relationship-list-item-header/relationship-list-item-header.tsx
@@ -11,7 +11,8 @@ import type { DBRelationship } from '@/lib/domain/db-relationship';
 import { useReactFlow } from '@xyflow/react';
 import { useChartDB } from '@/hooks/use-chartdb';
 import { useFocusOn } from '@/hooks/use-focus-on';
-import { useClickAway, useKeyPressEvent } from 'react-use';
+import { useEditClickOutside } from '@/hooks/use-click-outside';
+import { useKeyPressEvent } from 'react-use';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -42,31 +43,37 @@ export const RelationshipListItemHeader: React.FC<
     const inputRef = React.useRef<HTMLInputElement>(null);
 
     const editRelationshipName = useCallback(() => {
-        if (!editMode) return;
         if (relationshipName.trim() && relationshipName !== relationship.name) {
             updateRelationship(relationship.id, {
                 name: relationshipName.trim(),
             });
         }
-
         setEditMode(false);
     }, [
         relationshipName,
         relationship.id,
         updateRelationship,
-        editMode,
         relationship.name,
     ]);
 
-    useClickAway(inputRef, editRelationshipName);
-    useKeyPressEvent('Enter', editRelationshipName);
+    const abortEdit = useCallback(() => {
+        setEditMode(false);
+        setRelationshipName(relationship.name);
+    }, [relationship.name]);
 
-    const enterEditMode = (
-        event: React.MouseEvent<HTMLButtonElement, MouseEvent>
-    ) => {
-        event.stopPropagation();
-        setEditMode(true);
-    };
+    // Handle click outside to save and exit edit mode
+    useEditClickOutside(inputRef, editMode, editRelationshipName);
+    useKeyPressEvent('Enter', editRelationshipName);
+    useKeyPressEvent('Escape', abortEdit);
+
+    const enterEditMode = useCallback(
+        (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+            event.stopPropagation();
+            setRelationshipName(relationship.name);
+            setEditMode(true);
+        },
+        [relationship.name]
+    );
 
     const handleFocusOnRelationship = useCallback(
         (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {


### PR DESCRIPTION
- Create custom useClickOutside and useEditClickOutside hooks
- Replace useClickAway with custom hook for better event handling
- Add click-outside behavior to all edit fields:
  - Diagram name in navbar
  - Area names on canvas (with context menu)
  - Table names in side panel
  - Relationship names in side panel
  - Table edit mode panel
- Improve edit mode UX with auto-focus and text selection
- Add pencil icons for visual edit affordance