### PR TITLE
fix: support Delete key in addition to Backspace for canvas deletion

### DIFF
--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -1573,6 +1573,7 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables }) => {
                     snapGrid={[20, 20]}
                     onPaneClick={onPaneClickHandler}
                     connectionLineComponent={ConnectionLine}
+                    deleteKeyCode={['Backspace', 'Delete']}
                 >
                     <Controls
                         position="top-left"


### PR DESCRIPTION
  What it does:
  - Added deleteKeyCode={['Backspace', 'Delete']} prop to the ReactFlow component

  Why:
  - By default, React Flow only uses Backspace to delete selected objects (tables, relationships, notes) on the canvas
  - Mac users typically use Backspace (⌫)
  - Windows users typically use the Delete key
  - This change allows both keys to work for deletion