### PR TITLE
fix: resolve race condition between edge creation and handle registra…

### DIFF
--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -27,6 +27,7 @@ import {
     useReactFlow,
     useKeyPress,
     SelectionMode,
+    useUpdateNodeInternals,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import equal from 'fast-deep-equal';
@@ -164,6 +165,7 @@ const tableToTableNode = (
         showDBViews,
         forceShow,
         isRelationshipCreatingTarget = false,
+        targetEdgeCounts,
     }: {
         filter?: DiagramFilter;
         databaseType: DatabaseType;
@@ -171,6 +173,7 @@ const tableToTableNode = (
         showDBViews?: boolean;
         forceShow?: boolean;
         isRelationshipCreatingTarget?: boolean;
+        targetEdgeCounts?: Record<string, number>;
     }
 ): TableNodeType => {
     // Always use absolute position for now
@@ -199,6 +202,7 @@ const tableToTableNode = (
             table,
             isOverlapping: false,
             isRelationshipCreatingTarget,
+            targetEdgeCounts,
         },
         width: table.width ?? MIN_TABLE_SIZE,
         hidden,
@@ -271,6 +275,7 @@ export interface CanvasProps {
 
 export const Canvas: React.FC<CanvasProps> = ({ initialTables }) => {
     const { getEdge, getInternalNode, getNode } = useReactFlow();
+    const updateNodeInternals = useUpdateNodeInternals();
     const [selectedTableIds, setSelectedTableIds] = useState<string[]>([]);
     const [selectedRelationshipIds, setSelectedRelationshipIds] = useState<
         string[]
@@ -400,66 +405,78 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables }) => {
     }, [isInitialLoadingNodes, fitView]);
 
     useEffect(() => {
-        const targetIndexes: Record<string, number> = relationships.reduce(
-            (acc, relationship) => {
-                acc[
-                    `${relationship.targetTableId}${relationship.targetFieldId}`
-                ] = 0;
-                return acc;
-            },
-            {} as Record<string, number>
-        );
+        // Force React Flow to re-register handles for all table nodes
+        // This ensures handles exist before edges reference them
+        const tableNodeIds = tables.map((t) => t.id);
+        if (tableNodeIds.length > 0) {
+            updateNodeInternals(tableNodeIds);
+        }
 
-        const targetDepIndexes: Record<string, number> = dependencies.reduce(
-            (acc, dep) => {
-                acc[dep.tableId] = 0;
-                return acc;
-            },
-            {} as Record<string, number>
-        );
-
-        setEdges((prevEdges) => {
-            // Create a map of previous edge states to preserve selection
-            const prevEdgeStates = new Map(
-                prevEdges.map((edge) => [
-                    edge.id,
-                    { selected: edge.selected, animated: edge.animated },
-                ])
+        // Delay edge creation to ensure handles are registered
+        const timeoutId = setTimeout(() => {
+            const targetIndexes: Record<string, number> = relationships.reduce(
+                (acc, relationship) => {
+                    acc[
+                        `${relationship.targetTableId}${relationship.targetFieldId}`
+                    ] = 0;
+                    return acc;
+                },
+                {} as Record<string, number>
             );
 
-            return [
-                ...relationships.map((relationship): RelationshipEdgeType => {
-                    const prevState = prevEdgeStates.get(relationship.id);
-                    return {
-                        id: relationship.id,
-                        source: relationship.sourceTableId,
-                        target: relationship.targetTableId,
-                        sourceHandle: `${LEFT_HANDLE_ID_PREFIX}${relationship.sourceFieldId}`,
-                        targetHandle: `${TARGET_ID_PREFIX}${targetIndexes[`${relationship.targetTableId}${relationship.targetFieldId}`]++}_${relationship.targetFieldId}`,
-                        type: 'relationship-edge',
-                        data: { relationship },
-                        selected: prevState?.selected ?? false,
-                        animated: prevState?.animated ?? false,
-                    };
-                }),
-                ...dependencies.map((dep): DependencyEdgeType => {
-                    const prevState = prevEdgeStates.get(dep.id);
-                    return {
-                        id: dep.id,
-                        source: dep.dependentTableId,
-                        target: dep.tableId,
-                        sourceHandle: `${TOP_SOURCE_HANDLE_ID_PREFIX}${dep.dependentTableId}`,
-                        targetHandle: `${TARGET_DEP_PREFIX}${targetDepIndexes[dep.tableId]++}_${dep.tableId}`,
-                        type: 'dependency-edge',
-                        data: { dependency: dep },
-                        hidden: !showDBViews,
-                        selected: prevState?.selected ?? false,
-                        animated: prevState?.animated ?? false,
-                    };
-                }),
-            ];
-        });
-    }, [relationships, dependencies, setEdges, showDBViews]);
+            const targetDepIndexes: Record<string, number> = dependencies.reduce(
+                (acc, dep) => {
+                    acc[dep.tableId] = 0;
+                    return acc;
+                },
+                {} as Record<string, number>
+            );
+
+            setEdges((prevEdges) => {
+                // Create a map of previous edge states to preserve selection
+                const prevEdgeStates = new Map(
+                    prevEdges.map((edge) => [
+                        edge.id,
+                        { selected: edge.selected, animated: edge.animated },
+                    ])
+                );
+
+                return [
+                    ...relationships.map((relationship): RelationshipEdgeType => {
+                        const prevState = prevEdgeStates.get(relationship.id);
+                        return {
+                            id: relationship.id,
+                            source: relationship.sourceTableId,
+                            target: relationship.targetTableId,
+                            sourceHandle: `${LEFT_HANDLE_ID_PREFIX}${relationship.sourceFieldId}`,
+                            targetHandle: `${TARGET_ID_PREFIX}${targetIndexes[`${relationship.targetTableId}${relationship.targetFieldId}`]++}_${relationship.targetFieldId}`,
+                            type: 'relationship-edge',
+                            data: { relationship },
+                            selected: prevState?.selected ?? false,
+                            animated: prevState?.animated ?? false,
+                        };
+                    }),
+                    ...dependencies.map((dep): DependencyEdgeType => {
+                        const prevState = prevEdgeStates.get(dep.id);
+                        return {
+                            id: dep.id,
+                            source: dep.dependentTableId,
+                            target: dep.tableId,
+                            sourceHandle: `${TOP_SOURCE_HANDLE_ID_PREFIX}${dep.dependentTableId}`,
+                            targetHandle: `${TARGET_DEP_PREFIX}${targetDepIndexes[dep.tableId]++}_${dep.tableId}`,
+                            type: 'dependency-edge',
+                            data: { dependency: dep },
+                            hidden: !showDBViews,
+                            selected: prevState?.selected ?? false,
+                            animated: prevState?.animated ?? false,
+                        };
+                    }),
+                ];
+            });
+        }, 100); // Delay to let handles register after updateNodeInternals
+
+        return () => clearTimeout(timeoutId);
+    }, [relationships, dependencies, setEdges, showDBViews, tables, updateNodeInternals]);
 
     useEffect(() => {
         const selectedNodesIds = nodes
@@ -555,11 +572,28 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables }) => {
     }, [selectedRelationshipIds, selectedTableIds, setEdges]);
 
     useEffect(() => {
+        // Compute target edge counts per field (same logic as edge creation)
+        // This ensures handle creation is synchronized with edge indices
+        const targetEdgeCountsByField: Record<string, number> = {};
+        relationships.forEach((rel) => {
+            const fieldId = rel.targetFieldId;
+            targetEdgeCountsByField[fieldId] = (targetEdgeCountsByField[fieldId] || 0) + 1;
+        });
+
         setNodes((prevNodes) => {
             const newNodes = [
                 ...tables.map((table) => {
                     const isOverlapping =
                         (overlapGraph.graph.get(table.id) ?? []).length > 0;
+                    
+                    // Get target edge counts for this table's fields
+                    const tableTargetEdgeCounts: Record<string, number> = {};
+                    table.fields.forEach((field) => {
+                        if (targetEdgeCountsByField[field.id]) {
+                            tableTargetEdgeCounts[field.id] = targetEdgeCountsByField[field.id];
+                        }
+                    });
+
                     const node = tableToTableNode(table, {
                         filter,
                         databaseType,
@@ -567,6 +601,7 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables }) => {
                         showDBViews,
                         forceShow: shouldForceShowTable(table.id),
                         isRelationshipCreatingTarget: false,
+                        targetEdgeCounts: tableTargetEdgeCounts,
                     });
 
                     // Check if table uses the highlighted custom type
@@ -625,6 +660,7 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables }) => {
         filterLoading,
         showDBViews,
         shouldForceShowTable,
+        relationships,
     ]);
 
     // Surgical update for relationship creation target highlighting

--- a/src/pages/editor-page/canvas/table-node/table-node-field.tsx
+++ b/src/pages/editor-page/canvas/table-node/table-node-field.tsx
@@ -48,6 +48,8 @@ export interface TableNodeFieldProps {
     highlighted: boolean;
     visible: boolean;
     isConnectable: boolean;
+    // Target edge count passed from canvas to ensure sync with edge creation
+    targetEdgeCount?: number;
 }
 
 const arePropsEqual = (
@@ -72,12 +74,13 @@ const arePropsEqual = (
         prevProps.highlighted === nextProps.highlighted &&
         prevProps.visible === nextProps.visible &&
         prevProps.isConnectable === nextProps.isConnectable &&
-        prevProps.tableNodeId === nextProps.tableNodeId
+        prevProps.tableNodeId === nextProps.tableNodeId &&
+        prevProps.targetEdgeCount === nextProps.targetEdgeCount
     );
 };
 
 export const TableNodeField: React.FC<TableNodeFieldProps> = React.memo(
-    ({ field, focused, tableNodeId, highlighted, visible, isConnectable }) => {
+    ({ field, focused, tableNodeId, highlighted, visible, isConnectable, targetEdgeCount }) => {
         const { relationships, readonly, highlightedCustomType, databaseType } =
             useChartDB();
 
@@ -117,6 +120,11 @@ export const TableNodeField: React.FC<TableNodeFieldProps> = React.memo(
         );
 
         const numberOfEdgesToField = useMemo(() => {
+            // Use targetEdgeCount from canvas when available (ensures sync with edge creation)
+            if (targetEdgeCount !== undefined) {
+                return targetEdgeCount;
+            }
+            // Fallback: count from relationships
             let count = 0;
             for (const rel of relationships) {
                 if (
@@ -127,7 +135,7 @@ export const TableNodeField: React.FC<TableNodeFieldProps> = React.memo(
                 }
             }
             return count;
-        }, [relationships, tableNodeId, field.id]);
+        }, [targetEdgeCount, relationships, tableNodeId, field.id]);
 
         const isForeignKey = useMemo(() => {
             return relationships.some((rel) => {
@@ -154,18 +162,20 @@ export const TableNodeField: React.FC<TableNodeFieldProps> = React.memo(
             });
         }, [relationships, tableNodeId, field.id]);
 
-        const previousNumberOfEdgesToFieldRef = useRef(numberOfEdgesToField);
+        const previousNumberOfEdgesToFieldRef = useRef<number | null>(null);
 
         useEffect(() => {
+            // Always update on first render, then only when count changes
             if (
+                previousNumberOfEdgesToFieldRef.current === null ||
                 previousNumberOfEdgesToFieldRef.current !== numberOfEdgesToField
             ) {
-                const timer = setTimeout(() => {
+                // Use requestAnimationFrame for immediate but batched update
+                const frameId = requestAnimationFrame(() => {
                     updateNodeInternals(tableNodeId);
-                    previousNumberOfEdgesToFieldRef.current =
-                        numberOfEdgesToField;
-                }, 100);
-                return () => clearTimeout(timer);
+                    previousNumberOfEdgesToFieldRef.current = numberOfEdgesToField;
+                });
+                return () => cancelAnimationFrame(frameId);
             }
         }, [tableNodeId, updateNodeInternals, numberOfEdgesToField]);
 

--- a/src/pages/editor-page/canvas/table-node/table-node.tsx
+++ b/src/pages/editor-page/canvas/table-node/table-node.tsx
@@ -65,6 +65,8 @@ export type TableNodeType = Node<
         hasHighlightedCustomType?: boolean;
         highlightTable?: boolean;
         isRelationshipCreatingTarget?: boolean;
+        // Map of fieldId -> number of edges targeting that field (for handle creation)
+        targetEdgeCounts?: Record<string, number>;
     },
     'table'
 >;
@@ -81,6 +83,7 @@ export const TableNode: React.FC<NodeProps<TableNodeType>> = React.memo(
             hasHighlightedCustomType,
             highlightTable,
             isRelationshipCreatingTarget,
+            targetEdgeCounts,
         },
     }) => {
         const { updateTable, relationships, readonly } = useChartDB();
@@ -620,6 +623,7 @@ export const TableNode: React.FC<NodeProps<TableNodeType>> = React.memo(
                                 highlighted={highlightedFieldIds.has(field.id)}
                                 visible={true}
                                 isConnectable={!table.isView}
+                                targetEdgeCount={targetEdgeCounts?.[field.id]}
                             />
                         ))}
                     </div>


### PR DESCRIPTION
# Fix: Relationship lines not rendering due to React Flow handle race condition

## Summary

Fixes a race condition where relationship edges fail to render with React Flow errors:
```
[React Flow]: Couldn't create edge for target handle id: "target_rel_X_Y", edge id: Z
```

This occurs when multiple relationships target the same field, or when tables are dragged around the canvas.

## Problem

When a field has multiple incoming relationships (e.g., 7 foreign keys pointing to `brands.id`), the edges would intermittently fail to render. The console would show errors indicating that React Flow couldn't find the target handles for edges.

**Root cause**: A timing mismatch between:
1. Edge creation (which references handles by ID)
2. Handle rendering (which happens asynchronously in React)

The `TableNodeField` component was computing handle counts independently from the canvas's edge creation logic. When edges were created before handles finished registering, React Flow would error and not render those edges.

![broken](https://github.com/user-attachments/assets/8c170376-3f32-4f41-8dd8-2ac80580513e)

## Changes

### `canvas.tsx`
- Import and use `useUpdateNodeInternals` hook
- Compute `targetEdgeCounts` (how many edges target each field) and pass to table nodes
- Call `updateNodeInternals()` for all table nodes before edge creation to force handle registration
- Add slight delay (100ms) before edge creation to ensure handles are ready
- Add `tables` and `relationships` to effect dependencies to properly sync on changes

### `table-node.tsx`
- Add `targetEdgeCounts` to node data type
- Pass `targetEdgeCount` for each field to `TableNodeField` component

### `table-node-field.tsx`
- Accept `targetEdgeCount` prop from parent
- Prioritize passed `targetEdgeCount` over local calculation for handle count
- Use `requestAnimationFrame` instead of `setTimeout` for more reliable timing
- Initialize ref to `null` to ensure `updateNodeInternals` runs on first render

![fixed](https://github.com/user-attachments/assets/fc9c41a5-cdec-4d39-bb1a-01ed9e3de855)

## Test Plan

1. Import the included pgsql DBML
2. Verify 8 relationship lines render on initial load, leading to/from the `vendors` table
3. Drag the `vendors` table around the canvas
4. Verify relationship lines persist and don't disappear
5. Check console for absence of React Flow handle errors

### Reproduction DBML

This pgsql DBML will allow reproduction of the issue on main and demonstrate the fix on this PR:
```
// Reproduction case for React Flow handle race condition bug
// This schema has 7 foreign keys pointing to vendors.id, which triggers the issue
// where relationship lines fail to render with "Couldn't create edge for target handle" errors

Table "brands" {
  "id" uuid [primary key, not null, default: `gen_random_uuid()`]
  "canonical_name" text [not null]
  "canonical_handle" text [not null]
  "created_at" timestamp [not null, default: `now()`]
  "updated_at" timestamp [not null, default: `now()`]

  indexes {
    ("canonical_name") [unique, name: 'brands_canonical_name_uidx']
    ("canonical_handle") [unique, name: 'brands_canonical_handle_uidx']
  }
}

Table "vendors" {
  "id" uuid [primary key, not null, default: `gen_random_uuid()`]
  "brand_id" uuid [not null]
  "display_name" text
  "partner_type" text [not null, default: 'official-partner']
  "status" text [not null, default: 'available']
  "created_at" timestamp [not null, default: `now()`]
  "updated_at" timestamp [not null, default: `now()`]

  indexes {
    ("brand_id") [unique, name: 'vendors_brand_id_uidx']
  }
}

Table "vendor_assets" {
  "id" uuid [primary key, not null, default: `gen_random_uuid()`]
  "vendor_id" uuid [not null]
  "type" text [not null]
  "url" text [not null]
  "alt_text" text
  "width" integer
  "height" integer
  "mime_type" text
  "is_primary" boolean [not null, default: true]
  "sort_order" integer [not null, default: 0]
  "created_at" timestamp [not null, default: `now()`]
  "updated_at" timestamp [not null, default: `now()`]
}

Table "vendor_categories" {
  "id" uuid [primary key, not null, default: `gen_random_uuid()`]
  "vendor_id" uuid [not null]
  "category_id" uuid [not null]
  "created_at" timestamp [not null, default: `now()`]
  "updated_at" timestamp [not null, default: `now()`]

  indexes {
    ("vendor_id", "category_id") [unique, name: 'vendor_categories_vendor_id_category_id_uidx']
  }
}

Table "vendor_industries" {
  "id" uuid [primary key, not null, default: `gen_random_uuid()`]
  "vendor_id" uuid [not null]
  "industry_id" uuid [not null]
  "created_at" timestamp [not null, default: `now()`]
  "updated_at" timestamp [not null, default: `now()`]

  indexes {
    ("vendor_id", "industry_id") [unique, name: 'vendor_industries_vendor_id_industry_id_uidx']
  }
}

Table "vendor_locations" {
  "id" uuid [primary key, not null, default: `gen_random_uuid()`]
  "vendor_id" uuid [not null]
  "name" text [not null]
  "maps_url" text [not null]
  "is_primary" boolean [not null, default: true]
  "sort_order" integer [not null, default: 0]
  "created_at" timestamp [not null, default: `now()`]
  "updated_at" timestamp [not null, default: `now()`]
}

Table "vendor_products" {
  "id" uuid [primary key, not null, default: `gen_random_uuid()`]
  "vendor_id" uuid [not null]
  "product_id" uuid [not null]
  "created_at" timestamp [not null, default: `now()`]
  "updated_at" timestamp [not null, default: `now()`]

  indexes {
    ("vendor_id", "product_id") [unique, name: 'vendor_products_vendor_id_product_id_uidx']
  }
}

Table "vendor_seo" {
  "id" uuid [primary key, not null, default: `gen_random_uuid()`]
  "vendor_id" uuid [not null]
  "meta_title" text [not null]
  "meta_description" text [not null]
  "created_at" timestamp [not null, default: `now()`]
  "updated_at" timestamp [not null, default: `now()`]

  indexes {
    ("vendor_id") [unique, name: 'vendor_seo_vendor_id_uidx']
  }
}

Table "vendor_socials" {
  "id" uuid [primary key, not null, default: `gen_random_uuid()`]
  "vendor_id" uuid [not null]
  "type" text [not null]
  "url" text [not null]
  "created_at" timestamp [not null, default: `now()`]
  "updated_at" timestamp [not null, default: `now()`]

  indexes {
    ("vendor_id", "type") [unique, name: 'vendor_socials_vendor_id_type_uidx']
  }
}

Table "categories" {
  "id" uuid [primary key, not null, default: `gen_random_uuid()`]
  "name" text [not null]
  "handle" text [not null]
  "created_at" timestamp [not null, default: `now()`]
  "updated_at" timestamp [not null, default: `now()`]

  indexes {
    ("name") [unique, name: 'categories_name_uidx']
    ("handle") [unique, name: 'categories_handle_uidx']
  }
}

Table "industries" {
  "id" uuid [primary key, not null, default: `gen_random_uuid()`]
  "name" text [not null]
  "handle" text [not null]
  "created_at" timestamp [not null, default: `now()`]
  "updated_at" timestamp [not null, default: `now()`]

  indexes {
    ("name") [unique, name: 'industries_name_uidx']
    ("handle") [unique, name: 'industries_handle_uidx']
  }
}

Table "products" {
  "id" uuid [primary key, not null, default: `gen_random_uuid()`]
  "name" text [not null]
  "handle" text [not null]
  "created_at" timestamp [not null, default: `now()`]
  "updated_at" timestamp [not null, default: `now()`]

  indexes {
    ("name") [unique, name: 'products_name_uidx']
    ("handle") [unique, name: 'products_handle_uidx']
  }
}

// Relationships - 7 FKs pointing to vendors.id (this triggers the bug)
Ref: "vendor_assets"."vendor_id" > "vendors"."id" [delete: cascade]
Ref: "vendor_categories"."vendor_id" > "vendors"."id" [delete: cascade]
Ref: "vendor_industries"."vendor_id" > "vendors"."id" [delete: cascade]
Ref: "vendor_locations"."vendor_id" > "vendors"."id" [delete: cascade]
Ref: "vendor_products"."vendor_id" > "vendors"."id" [delete: cascade]
Ref: "vendor_seo"."vendor_id" > "vendors"."id" [delete: cascade]
Ref: "vendor_socials"."vendor_id" > "vendors"."id" [delete: cascade]

// Additional relationships
Ref: "vendors"."brand_id" > "brands"."id" [delete: cascade]
Ref: "vendor_categories"."category_id" > "categories"."id" [delete: cascade]
Ref: "vendor_industries"."industry_id" > "industries"."id" [delete: cascade]
Ref: "vendor_products"."product_id" > "products"."id" [delete: cascade]

```
