### PR TITLE
fix: change cursor style to pointer for dropdown menu items

### DIFF
--- a/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/src/components/dropdown-menu/dropdown-menu.tsx
@@ -86,7 +86,7 @@ const DropdownMenuItem = React.forwardRef<
     <DropdownMenuPrimitive.Item
         ref={ref}
         className={cn(
-            'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+            'relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
             inset && 'pl-8',
             className
         )}


### PR DESCRIPTION
This pull request makes a minor update to the `DropdownMenuItem` component to improve its usability. The only change is updating the cursor style from `default` to `pointer`, making it clearer to users that the menu item is clickable.

- Changed the `className` for `DropdownMenuItem` in `dropdown-menu.tsx` from `cursor-default` to `cursor-pointer` to indicate interactivity.