### PR TITLE
fix: change cursor style to pointer for dropdown menu items

### DIFF
--- a/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/src/components/dropdown-menu/dropdown-menu.tsx
@@ -86,7 +86,7 @@ const DropdownMenuItem = React.forwardRef<
     <DropdownMenuPrimitive.Item
         ref={ref}
         className={cn(
-            'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+            'relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
             inset && 'pl-8',
             className
         )}


### PR DESCRIPTION
I just made the cursor change to pointer when hovering over dropdown items.

<img width="1044" height="498" alt="yapıştırılmış dosya" src="https://github.com/user-attachments/assets/3baff91e-b67b-4b9b-80b5-e3f2e3267df8" />
