### PR TITLE
fix: font family declaration in Tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,7 +16,7 @@ module.exports = {
     	extend: {
     		fontFamily: {
     			primary: [
-    				'Raleway"',
+    				'Raleway',
                     ...defaultTheme.fontFamily.sans
                 ]
     		},


### PR DESCRIPTION
This PR fixes a build warning caused by a syntax error (extraneous double quote inside the single-quoted `'Raleway"'`) in the Tailwind CSS configuration.

A typo in the `fontFamily` declaration generated malformed CSS, which resulted in an unterminated string token error when compiling the stylesheet. This PR corrects the typo, allowing the build process to complete cleanly without warnings.

Running build previously threw the following warnings:

> ▲ [WARNING] Unterminated string token [css-syntax-error]
> 
>     <stdin>:2468:140:
>       2468 │ ...moji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
>            ╵                                                                   ^
> 
> 
> ▲ [WARNING] Unterminated string token [css-syntax-error]
> 
>     <stdin>:7473:140:
>       7473 │ ...moji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";          ^



