### PR TITLE
feat: add show/hide toolbar toggle in view menu

### DIFF
--- a/src/context/local-config-context/local-config-context.tsx
+++ b/src/context/local-config-context/local-config-context.tsx
@@ -28,6 +28,9 @@ export interface LocalConfigContext {
 
     showMiniMapOnCanvas: boolean;
     setShowMiniMapOnCanvas: (showMiniMapOnCanvas: boolean) => void;
+
+    showToolbar: boolean;
+    setShowToolbar: (showToolbar: boolean) => void;
 }
 
 export const LocalConfigContext = createContext<LocalConfigContext>({
@@ -54,4 +57,7 @@ export const LocalConfigContext = createContext<LocalConfigContext>({
 
     showMiniMapOnCanvas: false,
     setShowMiniMapOnCanvas: emptyFn,
+
+    showToolbar: true,
+    setShowToolbar: emptyFn,
 });

--- a/src/context/local-config-context/local-config-provider.tsx
+++ b/src/context/local-config-context/local-config-provider.tsx
@@ -11,6 +11,7 @@ const githubRepoOpenedKey = 'github_repo_opened';
 const starUsDialogLastOpenKey = 'star_us_dialog_last_open';
 const showMiniMapOnCanvasKey = 'show_minimap_on_canvas';
 const showDBViewsKey = 'show_db_views';
+const showToolbarKey = 'show_toolbar';
 
 export const LocalConfigProvider: React.FC<React.PropsWithChildren> = ({
     children,
@@ -50,6 +51,10 @@ export const LocalConfigProvider: React.FC<React.PropsWithChildren> = ({
             (localStorage.getItem(showMiniMapOnCanvasKey) || 'true') === 'true'
         );
 
+    const [showToolbar, setShowToolbar] = React.useState<boolean>(
+        (localStorage.getItem(showToolbarKey) || 'true') === 'true'
+    );
+
     useEffect(() => {
         localStorage.setItem(
             starUsDialogLastOpenKey,
@@ -84,6 +89,10 @@ export const LocalConfigProvider: React.FC<React.PropsWithChildren> = ({
         );
     }, [showMiniMapOnCanvas]);
 
+    useEffect(() => {
+        localStorage.setItem(showToolbarKey, showToolbar.toString());
+    }, [showToolbar]);
+
     return (
         <LocalConfigContext.Provider
             value={{
@@ -103,6 +112,8 @@ export const LocalConfigProvider: React.FC<React.PropsWithChildren> = ({
                 setStarUsDialogLastOpen,
                 showMiniMapOnCanvas,
                 setShowMiniMapOnCanvas,
+                showToolbar,
+                setShowToolbar,
             }}
         >
             {children}

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -44,6 +44,8 @@ export const ar: LanguageTranslation = {
                 // TODO: Translate
                 show_minimap: 'Show Mini Map',
                 hide_minimap: 'Hide Mini Map',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             backup: {
                 backup: 'النسخ الاحتياطي',

--- a/src/i18n/locales/bn.ts
+++ b/src/i18n/locales/bn.ts
@@ -44,6 +44,8 @@ export const bn: LanguageTranslation = {
                 // TODO: Translate
                 show_minimap: 'Show Mini Map',
                 hide_minimap: 'Hide Mini Map',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
 
             backup: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -44,6 +44,8 @@ export const de: LanguageTranslation = {
                 // TODO: Translate
                 show_minimap: 'Show Mini Map',
                 hide_minimap: 'Hide Mini Map',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             backup: {
                 backup: 'Sicherung',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -43,6 +43,8 @@ export const en = {
                 hide_dependencies: 'Hide Dependencies',
                 show_minimap: 'Show Mini Map',
                 hide_minimap: 'Hide Mini Map',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             backup: {
                 backup: 'Backup',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -44,6 +44,8 @@ export const es: LanguageTranslation = {
                 // TODO: Translate
                 show_minimap: 'Show Mini Map',
                 hide_minimap: 'Hide Mini Map',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             backup: {
                 backup: 'Respaldo',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -43,6 +43,8 @@ export const fr: LanguageTranslation = {
                 hide_dependencies: 'Masquer les Dépendances',
                 show_minimap: 'Afficher la Mini Carte',
                 hide_minimap: 'Masquer la Mini Carte',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             backup: {
                 backup: 'Sauvegarde',

--- a/src/i18n/locales/gu.ts
+++ b/src/i18n/locales/gu.ts
@@ -44,6 +44,8 @@ export const gu: LanguageTranslation = {
                 // TODO: Translate
                 show_minimap: 'Show Mini Map',
                 hide_minimap: 'Hide Mini Map',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
 
             backup: {

--- a/src/i18n/locales/hi.ts
+++ b/src/i18n/locales/hi.ts
@@ -44,6 +44,8 @@ export const hi: LanguageTranslation = {
                 // TODO: Translate
                 show_minimap: 'Show Mini Map',
                 hide_minimap: 'Hide Mini Map',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             backup: {
                 backup: 'बैकअप',

--- a/src/i18n/locales/hr.ts
+++ b/src/i18n/locales/hr.ts
@@ -43,6 +43,8 @@ export const hr: LanguageTranslation = {
                 hide_dependencies: 'Sakrij ovisnosti',
                 show_minimap: 'Prikaži mini kartu',
                 hide_minimap: 'Sakrij mini kartu',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             backup: {
                 backup: 'Sigurnosna kopija',

--- a/src/i18n/locales/id_ID.ts
+++ b/src/i18n/locales/id_ID.ts
@@ -44,6 +44,8 @@ export const id_ID: LanguageTranslation = {
                 // TODO: Translate
                 show_minimap: 'Show Mini Map',
                 hide_minimap: 'Hide Mini Map',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             backup: {
                 backup: 'Cadangan',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -45,6 +45,8 @@ export const ja: LanguageTranslation = {
                 // TODO: Translate
                 show_minimap: 'Show Mini Map',
                 hide_minimap: 'Hide Mini Map',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             backup: {
                 backup: 'バックアップ',

--- a/src/i18n/locales/ko_KR.ts
+++ b/src/i18n/locales/ko_KR.ts
@@ -44,6 +44,8 @@ export const ko_KR: LanguageTranslation = {
                 // TODO: Translate
                 show_minimap: 'Show Mini Map',
                 hide_minimap: 'Hide Mini Map',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             backup: {
                 backup: '백업',

--- a/src/i18n/locales/mr.ts
+++ b/src/i18n/locales/mr.ts
@@ -44,6 +44,8 @@ export const mr: LanguageTranslation = {
                 // TODO: Translate
                 show_minimap: 'Show Mini Map',
                 hide_minimap: 'Hide Mini Map',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             backup: {
                 // TODO: Add translations

--- a/src/i18n/locales/ne.ts
+++ b/src/i18n/locales/ne.ts
@@ -44,6 +44,8 @@ export const ne: LanguageTranslation = {
                 // TODO: Translate
                 show_minimap: 'Show Mini Map',
                 hide_minimap: 'Hide Mini Map',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             // TODO: Translate
             backup: {

--- a/src/i18n/locales/pt_BR.ts
+++ b/src/i18n/locales/pt_BR.ts
@@ -44,6 +44,8 @@ export const pt_BR: LanguageTranslation = {
                 // TODO: Translate
                 show_minimap: 'Show Mini Map',
                 hide_minimap: 'Hide Mini Map',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             // TODO: Translate
             backup: {

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -43,6 +43,8 @@ export const ru: LanguageTranslation = {
                 hide_dependencies: 'Скрыть зависимости',
                 show_minimap: 'Показать мини-карту',
                 hide_minimap: 'Скрыть мини-карту',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             backup: {
                 backup: 'Бэкап',

--- a/src/i18n/locales/te.ts
+++ b/src/i18n/locales/te.ts
@@ -44,6 +44,8 @@ export const te: LanguageTranslation = {
                 // TODO: Translate
                 show_minimap: 'Show Mini Map',
                 hide_minimap: 'Hide Mini Map',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             // TODO: Translate
             backup: {

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -44,6 +44,8 @@ export const tr: LanguageTranslation = {
                 // TODO: Translate
                 show_minimap: 'Show Mini Map',
                 hide_minimap: 'Hide Mini Map',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             // TODO: Translate
             backup: {

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -43,6 +43,8 @@ export const uk: LanguageTranslation = {
                 hide_dependencies: 'Приховати залежності',
                 show_minimap: 'Показати мінімапу',
                 hide_minimap: 'Приховати мінімапу',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             backup: {
                 backup: 'Резервне копіювання',

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -44,6 +44,8 @@ export const vi: LanguageTranslation = {
                 // TODO: Translate
                 show_minimap: 'Show Mini Map',
                 hide_minimap: 'Hide Mini Map',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             backup: {
                 backup: 'Hỗ trợ',

--- a/src/i18n/locales/zh_CN.ts
+++ b/src/i18n/locales/zh_CN.ts
@@ -44,6 +44,8 @@ export const zh_CN: LanguageTranslation = {
                 // TODO: Translate
                 show_minimap: 'Show Mini Map',
                 hide_minimap: 'Hide Mini Map',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             backup: {
                 backup: '备份',

--- a/src/i18n/locales/zh_TW.ts
+++ b/src/i18n/locales/zh_TW.ts
@@ -44,6 +44,8 @@ export const zh_TW: LanguageTranslation = {
                 // TODO: Translate
                 show_minimap: 'Show Mini Map',
                 hide_minimap: 'Hide Mini Map',
+                show_toolbar: 'Show Toolbar',
+                hide_toolbar: 'Hide Toolbar',
             },
             backup: {
                 backup: '備份',

--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -302,7 +302,8 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables }) => {
     } = useChartDB();
     const { showSidePanel } = useLayout();
     const { effectiveTheme } = useTheme();
-    const { scrollAction, showDBViews, showMiniMapOnCanvas } = useLocalConfig();
+    const { scrollAction, showDBViews, showMiniMapOnCanvas, showToolbar } =
+        useLocalConfig();
     const { isMd: isDesktop } = useBreakpoint('md');
     const [highlightOverlappingTables, setHighlightOverlappingTables] =
         useState(false);
@@ -1806,16 +1807,20 @@ export const Canvas: React.FC<CanvasProps> = ({ initialTables }) => {
                             <ShowAllButton />
                         </Controls>
                     ) : null}
-                    <Controls
-                        position={isDesktop ? 'bottom-center' : 'top-center'}
-                        orientation="horizontal"
-                        showZoom={false}
-                        showFitView={false}
-                        showInteractive={false}
-                        className="!shadow-none"
-                    >
-                        <Toolbar readonly={readonly} />
-                    </Controls>
+                    {showToolbar && (
+                        <Controls
+                            position={
+                                isDesktop ? 'bottom-center' : 'top-center'
+                            }
+                            orientation="horizontal"
+                            showZoom={false}
+                            showFitView={false}
+                            showInteractive={false}
+                            className="!shadow-none"
+                        >
+                            <Toolbar readonly={readonly} />
+                        </Controls>
+                    )}
                     {showMiniMapOnCanvas && (
                         <MiniMap
                             style={{

--- a/src/pages/editor-page/top-navbar/menu/menu.tsx
+++ b/src/pages/editor-page/top-navbar/menu/menu.tsx
@@ -61,6 +61,8 @@ export const Menu: React.FC<MenuProps> = () => {
         showMiniMapOnCanvas,
         showDBViews,
         setShowDBViews,
+        showToolbar,
+        setShowToolbar,
     } = useLocalConfig();
     const { t } = useTranslation();
     const { redo, undo, hasRedo, hasUndo } = useHistory();
@@ -144,6 +146,10 @@ export const Menu: React.FC<MenuProps> = () => {
     const showOrHideMiniMap = useCallback(() => {
         setShowMiniMapOnCanvas(!showMiniMapOnCanvas);
     }, [showMiniMapOnCanvas, setShowMiniMapOnCanvas]);
+
+    const showOrHideToolbar = useCallback(() => {
+        setShowToolbar(!showToolbar);
+    }, [showToolbar, setShowToolbar]);
 
     const emojiAI = '✨';
 
@@ -396,6 +402,11 @@ export const Menu: React.FC<MenuProps> = () => {
                         {showMiniMapOnCanvas
                             ? t('menu.view.hide_minimap')
                             : t('menu.view.show_minimap')}
+                    </MenubarItem>
+                    <MenubarItem onClick={showOrHideToolbar}>
+                        {showToolbar
+                            ? t('menu.view.hide_toolbar')
+                            : t('menu.view.show_toolbar')}
                     </MenubarItem>
                     <MenubarSeparator />
                     <MenubarSub>


### PR DESCRIPTION
Fixes #497

## Summary
- Adds a "Show Toolbar" / "Hide Toolbar" toggle in the View menu, following the same pattern as existing toggles (minimap, cardinality, field attributes)
- Toolbar visibility state is persisted to localStorage via the existing `LocalConfigContext` pattern
- Translation keys added to all 22 locale files

## Changes
- `local-config-context.tsx` - added `showToolbar` / `setShowToolbar` to the context interface and defaults
- `local-config-provider.tsx` - added localStorage-backed state and persistence for `show_toolbar`
- `menu.tsx` - added toggle menu item in the View menu (between minimap and the zoom-on-scroll separator)
- `canvas.tsx` - conditionally renders the toolbar `<Controls>` wrapper based on `showToolbar`
- All locale files - added `show_toolbar` and `hide_toolbar` translation keys

## Test plan
- [ ] Open the View menu and verify "Hide Toolbar" appears (toolbar is visible by default)
- [ ] Click "Hide Toolbar" and verify the toolbar disappears from the canvas
- [ ] Open the View menu again and verify it now says "Show Toolbar"
- [ ] Click "Show Toolbar" and verify the toolbar reappears
- [ ] Refresh the page and verify the preference is persisted

---
Developed with AI assistance (Claude Code)