### PR TITLE
fix: add cursor-pointer to database option buttons

### DIFF
--- a/src/components/toggle/toggle-variants.tsx
+++ b/src/components/toggle/toggle-variants.tsx
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 const toggleVariants = cva(
-    'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground',
+    'inline-flex cursor-pointer items-center justify-center rounded-md text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground',
     {
         variants: {
             variant: {


### PR DESCRIPTION
Fixes #1084

## Problem
When hovering over database options in the create diagram dialog, the cursor doesn't change to a pointer, making it unclear that the items are clickable.

## Solution
Added `cursor-pointer` class to the toggle variants in `toggle-variants.tsx`. This ensures all toggle items (including database options) show the correct cursor on hover.

## Changes
- Added `cursor-pointer` to the base toggle variant classes

## Testing
- Verified the change compiles successfully
- Ran linting (auto-fixed class ordering)
- Tests pass (408 passed, 1 pre-existing failure unrelated to this change)