### PR TITLE
feat: add app version number to sidebar footer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN echo "VITE_OPENAI_API_KEY=${VITE_OPENAI_API_KEY}" > .env && \
     echo "VITE_HIDE_CHARTDB_CLOUD=${VITE_HIDE_CHARTDB_CLOUD}" >> .env && \
     echo "VITE_DISABLE_ANALYTICS=${VITE_DISABLE_ANALYTICS}" >> .env
 
+RUN npm run prebuild
 RUN npm run build
 
 FROM nginx:stable-alpine AS production

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
+        "prebuild": "node -p \"'export const APP_VERSION = \\'' + require('./package.json').version + '\\';'\" > src/lib/version.ts",
         "build": "npm run lint && tsc -b && vite build",
         "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
         "lint:fix": "npm run lint -- --fix",

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,1 @@
+export const APP_VERSION = '1.20.1';

--- a/src/pages/editor-page/editor-sidebar/editor-sidebar.tsx
+++ b/src/pages/editor-page/editor-sidebar/editor-sidebar.tsx
@@ -30,6 +30,7 @@ import { useChartDB } from '@/hooks/use-chartdb';
 import { supportsCustomTypes } from '@/lib/domain/database-capabilities';
 import { useDialog } from '@/hooks/use-dialog';
 import { Separator } from '@/components/separator/separator';
+import { APP_VERSION } from '@/lib/version';
 
 export interface SidebarItem {
     title: string;
@@ -273,6 +274,9 @@ export const EditorSidebar: React.FC<EditorSidebarProps> = () => {
                         </SidebarMenuItem>
                     ))}
                 </SidebarMenu>
+                <small className="flex justify-center space-y-0.5 text-xs opacity-50">
+                    <span>v{APP_VERSION}</span>
+                </small>
             </SidebarFooter>
         </Sidebar>
     );


### PR DESCRIPTION
Closes #753

## Summary
- Adds ChartDB version to the bottom of the sidebar

## Changes
- `package.json`- added `prebuild` script to copy version number to `src/lib/version.ts`
- `Dockerfile` - added `prebuild` script execution
- `editor-sidebar.tsx` - added `<small>` with app version at the end of `<SidebarFooter>`