### PR TITLE
Feat/add easier schema addition in schema picker

### DIFF
--- a/src/components/select-box/select-box.tsx
+++ b/src/components/select-box/select-box.tsx
@@ -41,7 +41,7 @@ export interface SelectBoxProps {
     ) => void;
     placeholder?: string;
     inputPlaceholder?: string;
-    emptyPlaceholder?: string;
+    emptyPlaceholder?: React.ReactNode;
     className?: string;
     multiple?: boolean;
     oneLine?: boolean;

--- a/src/dialogs/table-schema-dialog/table-schema-dialog.tsx
+++ b/src/dialogs/table-schema-dialog/table-schema-dialog.tsx
@@ -131,10 +131,12 @@ export const TableSchemaDialog: React.FC<TableSchemaDialogProps> = ({
                 ) : (
                     <Group className="mr-2 size-4 " />
                 )}
-                {isCreatingNew ? 'Select existing schema' : 'Create new schema'}
+                {isCreatingNew
+                    ? t('create_table_schema_dialog.select_existing')
+                    : t('create_table_schema_dialog.create_new')}
             </Button>
         ),
-        [isCreatingNew, allowSchemaSelection, allowSchemaCreation]
+        [isCreatingNew, allowSchemaSelection, allowSchemaCreation, t]
     );
 
     return (
@@ -203,7 +205,7 @@ export const TableSchemaDialog: React.FC<TableSchemaDialogProps> = ({
                                 <div className="relative">
                                     <Separator className="my-2" />
                                     <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-background px-2 text-xs text-muted-foreground">
-                                        or
+                                        {t('create_table_schema_dialog.or')}
                                     </span>
                                 </div>
                                 {allowSchemaSelection ? (

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -114,6 +114,10 @@ export const ar: LanguageTranslation = {
         copy_to_clipboard: 'نسخ إلى الحافظة',
         copied: '!تم النسخ',
 
+        select_box: {
+            no_results: 'لم يتم العثور على نتائج.',
+        },
+
         side_panel: {
             view_all_options: '...عرض جميع الخيارات',
             tables_section: {
@@ -454,6 +458,10 @@ export const ar: LanguageTranslation = {
             title: 'إنشاء مخطط جديد',
             description:
                 'لا توجد مخططات حتى الآن. قم بإنشاء أول مخطط لتنظيم جداولك.',
+            or: 'أو',
+            select_existing: 'اختر مخططًا موجودًا',
+            create_new: 'أنشئ مخططًا جديدًا',
+            quick_create: 'إنشاء مخطط "{{schemaName}}"',
             create: 'إنشاء',
             cancel: 'إلغاء',
         },

--- a/src/i18n/locales/bn.ts
+++ b/src/i18n/locales/bn.ts
@@ -115,6 +115,10 @@ export const bn: LanguageTranslation = {
         copy_to_clipboard: 'ক্লিপবোর্ডে অনুলিপি করুন',
         copied: 'অনুলিপি সম্পন্ন!',
 
+        select_box: {
+            no_results: 'কোন ফলাফল পাওয়া যায়নি।',
+        },
+
         side_panel: {
             view_all_options: 'সমস্ত বিকল্প দেখুন...',
             tables_section: {
@@ -462,6 +466,10 @@ export const bn: LanguageTranslation = {
             title: 'নতুন স্কিমা তৈরি করুন',
             description:
                 'এখনও কোনো স্কিমা নেই। আপনার টেবিলগুলি সংগঠিত করতে আপনার প্রথম স্কিমা তৈরি করুন।',
+            or: 'অথবা',
+            select_existing: 'বিদ্যমান স্কিমা নির্বাচন করুন',
+            create_new: 'নতুন স্কিমা তৈরি করুন',
+            quick_create: 'স্কিমা "{{schemaName}}" তৈরি করুন',
             create: 'তৈরি করুন',
             cancel: 'বাতিল করুন',
         },

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -115,6 +115,10 @@ export const de: LanguageTranslation = {
         copy_to_clipboard: 'In die Zwischenablage kopieren',
         copied: 'Kopiert!',
 
+        select_box: {
+            no_results: 'Keine Ergebnisse gefunden.',
+        },
+
         side_panel: {
             view_all_options: 'Alle Optionen anzeigen...',
             tables_section: {
@@ -463,6 +467,10 @@ export const de: LanguageTranslation = {
             title: 'Neues Schema erstellen',
             description:
                 'Es existieren noch keine Schemas. Erstellen Sie Ihr erstes Schema, um Ihre Tabellen zu organisieren.',
+            or: 'oder',
+            select_existing: 'Vorhandenes Schema auswählen',
+            create_new: 'Neues Schema erstellen',
+            quick_create: 'Schema "{{schemaName}}" erstellen',
             create: 'Erstellen',
             cancel: 'Abbrechen',
         },

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -113,6 +113,10 @@ export const en = {
         copy_to_clipboard: 'Copy to Clipboard',
         copied: 'Copied!',
 
+        select_box: {
+            no_results: 'No results found.',
+        },
+
         side_panel: {
             view_all_options: 'View all Options...',
             tables_section: {
@@ -451,6 +455,10 @@ export const en = {
             title: 'Create New Schema',
             description:
                 'No schemas exist yet. Create your first schema to organize your tables.',
+            or: 'or',
+            select_existing: 'Select existing schema',
+            create_new: 'Create new schema',
+            quick_create: 'Create schema "{{schemaName}}"',
             create: 'Create',
             cancel: 'Cancel',
         },

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -114,6 +114,10 @@ export const es: LanguageTranslation = {
         copy_to_clipboard: 'Copy to Clipboard',
         copied: 'Copied!',
 
+        select_box: {
+            no_results: 'No se encontraron resultados.',
+        },
+
         side_panel: {
             view_all_options: 'Ver todas las opciones...',
             tables_section: {
@@ -462,6 +466,10 @@ export const es: LanguageTranslation = {
             title: 'Crear Nuevo Esquema',
             description:
                 'Aún no existen esquemas. Crea tu primer esquema para organizar tus tablas.',
+            or: 'o',
+            select_existing: 'Seleccionar esquema existente',
+            create_new: 'Crear nuevo esquema',
+            quick_create: 'Crear esquema "{{schemaName}}"',
             create: 'Crear',
             cancel: 'Cancelar',
         },

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -113,6 +113,10 @@ export const fr: LanguageTranslation = {
         copy_to_clipboard: 'Copier dans le presse-papiers',
         copied: 'Copié !',
 
+        select_box: {
+            no_results: 'Aucun résultat trouvé.',
+        },
+
         side_panel: {
             view_all_options: 'Voir toutes les Options...',
             tables_section: {
@@ -432,6 +436,10 @@ export const fr: LanguageTranslation = {
             title: 'Créer un Nouveau Schéma',
             description:
                 "Aucun schéma n'existe encore. Créez votre premier schéma pour organiser vos tables.",
+            or: 'ou',
+            select_existing: 'Sélectionner un schéma existant',
+            create_new: 'Créer un nouveau schéma',
+            quick_create: 'Créer le schéma "{{schemaName}}"',
             create: 'Créer',
             cancel: 'Annuler',
         },

--- a/src/i18n/locales/gu.ts
+++ b/src/i18n/locales/gu.ts
@@ -115,6 +115,10 @@ export const gu: LanguageTranslation = {
         copy_to_clipboard: 'ક્લિપબોર્ડમાં નકલ કરો',
         copied: 'નકલ થયું!',
 
+        select_box: {
+            no_results: 'કોઈ પરિણામ મળ્યા નથી.',
+        },
+
         side_panel: {
             view_all_options: 'બધા વિકલ્પો જુઓ...',
             tables_section: {
@@ -460,6 +464,10 @@ export const gu: LanguageTranslation = {
             title: 'નવું સ્કીમા બનાવો',
             description:
                 'હજી સુધી કોઈ સ્કીમા અસ્તિત્વમાં નથી. તમારા ટેબલ્સ ને વ્યવસ્થિત કરવા માટે તમારું પહેલું સ્કીમા બનાવો.',
+            or: 'અથવા',
+            select_existing: 'મોજૂદા સ્કીમા પસંદ કરો',
+            create_new: 'નવું સ્કીમા બનાવો',
+            quick_create: 'સ્કીમા "{{schemaName}}" બનાવો',
             create: 'બનાવો',
             cancel: 'રદ કરો',
         },

--- a/src/i18n/locales/hi.ts
+++ b/src/i18n/locales/hi.ts
@@ -115,6 +115,10 @@ export const hi: LanguageTranslation = {
         copy_to_clipboard: 'Copy to Clipboard',
         copied: 'Copied!',
 
+        select_box: {
+            no_results: 'कोई परिणाम नहीं मिले।',
+        },
+
         side_panel: {
             view_all_options: 'सभी विकल्प देखें...',
             tables_section: {
@@ -464,6 +468,10 @@ export const hi: LanguageTranslation = {
             title: 'नया स्कीमा बनाएं',
             description:
                 'अभी तक कोई स्कीमा मौजूद नहीं है। अपनी तालिकाओं को व्यवस्थित करने के लिए अपना पहला स्कीमा बनाएं।',
+            or: 'या',
+            select_existing: 'मौजूदा स्कीमा चुनें',
+            create_new: 'नया स्कीमा बनाएं',
+            quick_create: 'स्कीमा "{{schemaName}}" बनाएँ',
             create: 'बनाएं',
             cancel: 'रद्द करें',
         },

--- a/src/i18n/locales/hr.ts
+++ b/src/i18n/locales/hr.ts
@@ -113,6 +113,10 @@ export const hr: LanguageTranslation = {
         copy_to_clipboard: 'Kopiraj u međuspremnik',
         copied: 'Kopirano!',
 
+        select_box: {
+            no_results: 'Nema pronađenih rezultata.',
+        },
+
         side_panel: {
             view_all_options: 'Prikaži sve opcije...',
             tables_section: {
@@ -455,6 +459,10 @@ export const hr: LanguageTranslation = {
             title: 'Stvori novu shemu',
             description:
                 'Još ne postoje sheme. Stvorite svoju prvu shemu za organiziranje tablica.',
+            or: 'ili',
+            select_existing: 'Odaberite postojeću shemu',
+            create_new: 'Stvori novu shemu',
+            quick_create: 'Izradi shemu "{{schemaName}}"',
             create: 'Stvori',
             cancel: 'Odustani',
         },

--- a/src/i18n/locales/id_ID.ts
+++ b/src/i18n/locales/id_ID.ts
@@ -114,6 +114,10 @@ export const id_ID: LanguageTranslation = {
         copy_to_clipboard: 'Salin ke Clipboard',
         copied: 'Tersalin!',
 
+        select_box: {
+            no_results: 'Tidak ada hasil ditemukan.',
+        },
+
         side_panel: {
             view_all_options: 'Tampilkan Semua Pilihan...',
             tables_section: {
@@ -459,6 +463,10 @@ export const id_ID: LanguageTranslation = {
             title: 'Buat Skema Baru',
             description:
                 'Belum ada skema yang tersedia. Buat skema pertama Anda untuk mengatur tabel-tabel Anda.',
+            or: 'atau',
+            select_existing: 'Pilih skema yang sudah ada',
+            create_new: 'Buat skema baru',
+            quick_create: 'Buat skema "{{schemaName}}"',
             create: 'Buat',
             cancel: 'Batal',
         },

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -117,6 +117,10 @@ export const ja: LanguageTranslation = {
         copy_to_clipboard: 'Copy to Clipboard',
         copied: 'Copied!',
 
+        select_box: {
+            no_results: '結果が見つかりません。',
+        },
+
         side_panel: {
             view_all_options: 'すべてのオプションを表示...',
             tables_section: {
@@ -464,6 +468,10 @@ export const ja: LanguageTranslation = {
             title: '新しいスキーマを作成',
             description:
                 'スキーマがまだ存在しません。テーブルを整理するために最初のスキーマを作成してください。',
+            or: 'または',
+            select_existing: '既存のスキーマを選択',
+            create_new: '新しいスキーマを作成',
+            quick_create: 'スキーマ「{{schemaName}}」を作成',
             create: '作成',
             cancel: 'キャンセル',
         },

--- a/src/i18n/locales/ko_KR.ts
+++ b/src/i18n/locales/ko_KR.ts
@@ -114,6 +114,10 @@ export const ko_KR: LanguageTranslation = {
         copy_to_clipboard: '클립보드에 복사',
         copied: '복사됨!',
 
+        select_box: {
+            no_results: '결과를 찾을 수 없습니다.',
+        },
+
         side_panel: {
             view_all_options: '전체 옵션 보기...',
             tables_section: {
@@ -459,6 +463,10 @@ export const ko_KR: LanguageTranslation = {
             title: '새 스키마 생성',
             description:
                 '아직 스키마가 없습니다. 테이블을 정리하기 위해 첫 번째 스키마를 생성하세요.',
+            or: '또는',
+            select_existing: '기존 스키마 선택',
+            create_new: '새 스키마 생성',
+            quick_create: '스키마 "{{schemaName}}" 만들기',
             create: '생성',
             cancel: '취소',
         },

--- a/src/i18n/locales/mr.ts
+++ b/src/i18n/locales/mr.ts
@@ -117,6 +117,10 @@ export const mr: LanguageTranslation = {
         // TODO: Add translations
         copied: 'Copied!',
 
+        select_box: {
+            no_results: 'कोणतेही परिणाम सापडले नाहीत.',
+        },
+
         side_panel: {
             view_all_options: 'सर्व पर्याय पहा...',
             tables_section: {
@@ -467,6 +471,10 @@ export const mr: LanguageTranslation = {
             title: 'नवीन स्कीमा तयार करा',
             description:
                 'अजून कोणतीही स्कीमा अस्तित्वात नाही. आपल्या टेबल्स व्यवस्थित करण्यासाठी आपली पहिली स्कीमा तयार करा.',
+            or: 'किंवा',
+            select_existing: 'विद्यमान स्कीमा निवडा',
+            create_new: 'नवीन स्कीमा तयार करा',
+            quick_create: 'स्कीमा "{{schemaName}}" तयार करा',
             create: 'तयार करा',
             cancel: 'रद्द करा',
         },

--- a/src/i18n/locales/ne.ts
+++ b/src/i18n/locales/ne.ts
@@ -115,6 +115,10 @@ export const ne: LanguageTranslation = {
         copy_to_clipboard: 'क्लिपबोर्डमा प्रतिलिपि गर्नुहोस्',
         copied: 'प्रतिलिपि गरियो!',
 
+        select_box: {
+            no_results: 'कुनै परिणाम भेटिएन।',
+        },
+
         side_panel: {
             view_all_options: 'सबै विकल्पहरू हेर्नुहोस्',
             tables_section: {
@@ -463,6 +467,10 @@ export const ne: LanguageTranslation = {
             title: 'नयाँ स्कीम सिर्जना गर्नुहोस्',
             description:
                 'अहिलेसम्म कुनै स्कीम अस्तित्वमा छैन। आफ्ना तालिकाहरू व्यवस्थित गर्न आफ्नो पहिलो स्कीम सिर्जना गर्नुहोस्।',
+            or: 'वा',
+            select_existing: 'अवस्थित स्किमा चयन गर्नुहोस्',
+            create_new: 'नयाँ स्किमा सिर्जना गर्नुहोस्',
+            quick_create: 'स्किमा "{{schemaName}}" सिर्जना गर्नुहोस्',
             create: 'सिर्जना गर्नुहोस्',
             cancel: 'रद्द गर्नुहोस्',
         },

--- a/src/i18n/locales/pt_BR.ts
+++ b/src/i18n/locales/pt_BR.ts
@@ -115,6 +115,10 @@ export const pt_BR: LanguageTranslation = {
         copy_to_clipboard: 'Copiar para a Área de Transferência',
         copied: 'Copiado!',
 
+        select_box: {
+            no_results: 'Nenhum resultado encontrado.',
+        },
+
         side_panel: {
             view_all_options: 'Ver todas as Opções...',
             tables_section: {
@@ -463,6 +467,10 @@ export const pt_BR: LanguageTranslation = {
             title: 'Criar Novo Esquema',
             description:
                 'Ainda não existem esquemas. Crie seu primeiro esquema para organizar suas tabelas.',
+            or: 'ou',
+            select_existing: 'Selecionar esquema existente',
+            create_new: 'Criar novo esquema',
+            quick_create: 'Criar esquema "{{schemaName}}"',
             create: 'Criar',
             cancel: 'Cancelar',
         },

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -460,6 +460,10 @@ export const ru: LanguageTranslation = {
             title: 'Создать новую схему',
             description:
                 'Схемы еще не существуют. Создайте вашу первую схему, чтобы организовать таблицы.',
+            or: 'или',
+            select_existing: 'Выбрать существующую схему',
+            create_new: 'Создать новую схему',
+            quick_create: 'Создать схему «{{schemaName}}»',
             create: 'Создать',
             cancel: 'Отменить',
         },
@@ -551,6 +555,9 @@ export const ru: LanguageTranslation = {
 
         copy_to_clipboard: 'Скопировать в буфер обмена',
         copied: 'Скопировано!',
+        select_box: {
+            no_results: 'Результаты не найдены.',
+        },
         snap_to_grid_tooltip: 'Выравнивание по сетке (Удерживайте {{key}})',
         tool_tips: {
             double_click_to_edit: 'Кликните дважды, чтобы изменить',

--- a/src/i18n/locales/te.ts
+++ b/src/i18n/locales/te.ts
@@ -115,6 +115,10 @@ export const te: LanguageTranslation = {
         copy_to_clipboard: 'క్లిప్బోర్డుకు కాపీ చేయండి',
         copied: 'కాపీ చేయబడింది!',
 
+        select_box: {
+            no_results: 'ఫలితాలు కనుగొనబడలేదు.',
+        },
+
         side_panel: {
             view_all_options: 'అన్ని ఎంపికలను చూడండి...',
             tables_section: {
@@ -462,6 +466,10 @@ export const te: LanguageTranslation = {
             title: 'కొత్త స్కీమా సృష్టించండి',
             description:
                 'ఇంకా ఏ స్కీమాలు లేవు. మీ పట్టికలను వ్యవస్థీకరించడానికి మీ మొదటి స్కీమాను సృష్టించండి.',
+            or: 'లేదా',
+            select_existing: 'ఉన్న స్కీమాను ఎంచుకోండి',
+            create_new: 'కొత్త స్కీమాను సృష్టించండి',
+            quick_create: 'స్కీమా "{{schemaName}}" సృష్టించండి',
             create: 'సృష్టించు',
             cancel: 'రద్దు',
         },

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -114,6 +114,9 @@ export const tr: LanguageTranslation = {
         show_less: 'Daha Az Göster',
         copy_to_clipboard: 'Panoya Kopyala',
         copied: 'Kopyalandı!',
+        select_box: {
+            no_results: 'Sonuç bulunamadı.',
+        },
         side_panel: {
             view_all_options: 'Tüm Seçenekleri Gör...',
             tables_section: {
@@ -451,6 +454,10 @@ export const tr: LanguageTranslation = {
             title: 'Yeni Şema Oluştur',
             description:
                 'Henüz hiç şema mevcut değil. Tablolarınızı düzenlemek için ilk şemanızı oluşturun.',
+            or: 'veya',
+            select_existing: 'Mevcut şemayı seç',
+            create_new: 'Yeni şema oluştur',
+            quick_create: '"{{schemaName}}" şemasını oluştur',
             create: 'Oluştur',
             cancel: 'İptal',
         },

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -113,6 +113,10 @@ export const uk: LanguageTranslation = {
         copy_to_clipboard: 'Копіювати в буфер обміну',
         copied: 'Скопійовано!',
 
+        select_box: {
+            no_results: 'Результатів не знайдено.',
+        },
+
         side_panel: {
             view_all_options: 'Переглянути всі параметри…',
             tables_section: {
@@ -461,6 +465,10 @@ export const uk: LanguageTranslation = {
             title: 'Створити нову схему',
             description:
                 'Поки що не існує жодної схеми. Створіть свою першу схему, щоб організувати ваші таблиці.',
+            or: 'або',
+            select_existing: 'Вибрати існуючу схему',
+            create_new: 'Створити нову схему',
+            quick_create: 'Створити схему "{{schemaName}}"',
             create: 'Створити',
             cancel: 'Скасувати',
         },

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -114,6 +114,10 @@ export const vi: LanguageTranslation = {
         copy_to_clipboard: 'Sao chép vào bảng tạm',
         copied: 'Đã sao chép!',
 
+        select_box: {
+            no_results: 'Không tìm thấy kết quả.',
+        },
+
         side_panel: {
             view_all_options: 'Xem tất cả tùy chọn...',
             tables_section: {
@@ -459,6 +463,10 @@ export const vi: LanguageTranslation = {
             title: 'Tạo lược đồ mới',
             description:
                 'Chưa có lược đồ nào. Tạo lược đồ đầu tiên của bạn để tổ chức các bảng.',
+            or: 'hoặc',
+            select_existing: 'Chọn lược đồ hiện có',
+            create_new: 'Tạo lược đồ mới',
+            quick_create: 'Tạo lược đồ "{{schemaName}}"',
             create: 'Tạo',
             cancel: 'Hủy',
         },

--- a/src/i18n/locales/zh_CN.ts
+++ b/src/i18n/locales/zh_CN.ts
@@ -111,6 +111,10 @@ export const zh_CN: LanguageTranslation = {
         copy_to_clipboard: '复制到剪切板',
         copied: '复制了！',
 
+        select_box: {
+            no_results: '未找到结果。',
+        },
+
         side_panel: {
             view_all_options: '查看所有选项...',
             tables_section: {
@@ -451,6 +455,10 @@ export const zh_CN: LanguageTranslation = {
         create_table_schema_dialog: {
             title: '创建新模式',
             description: '尚未存在任何模式。创建您的第一个模式来组织您的表。',
+            or: '或',
+            select_existing: '选择现有模式',
+            create_new: '创建新模式',
+            quick_create: '创建模式“{{schemaName}}”',
             create: '创建',
             cancel: '取消',
         },

--- a/src/i18n/locales/zh_TW.ts
+++ b/src/i18n/locales/zh_TW.ts
@@ -111,6 +111,10 @@ export const zh_TW: LanguageTranslation = {
         copy_to_clipboard: '複製到剪貼簿',
         copied: '已複製！',
 
+        select_box: {
+            no_results: '找不到結果。',
+        },
+
         side_panel: {
             view_all_options: '顯示所有選項...',
             tables_section: {
@@ -451,6 +455,7 @@ export const zh_TW: LanguageTranslation = {
             title: '建立新 Schema',
             description:
                 '尚未存在任何 Schema。建立您的第一個 Schema 來組織您的表格。',
+            quick_create: '建立 Schema「{{schemaName}}」',
             create: '建立',
             cancel: '取消',
         },

--- a/src/pages/editor-page/side-panel/tables-section/tables-section.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/tables-section.tsx
@@ -113,6 +113,7 @@ export const TablesSection: React.FC<TablesSectionProps> = () => {
                         ? createViewWithLocation
                         : createTableWithLocation,
                     schemas: schemasDisplayed,
+                    allowSchemaCreation: true,
                 });
             } else {
                 const schema =


### PR DESCRIPTION
Added the ability to create schemas more easily by adding a dedicated "create new schema" button in the table creation menu.

Previously when you had 2 or more schemas the UI would prompt you to select a schema without giving you the ability to easily create a new schema, which has lead to unnecessary navigation to get the schema created. This pull request aims to fix it.

I (with the help of Copilot) have also added the necessary translation keys for other languages related to this feature, I have also attached some screenshots to directly preview how the changes look like.

<img width="769" height="462" alt="grafik" src="https://github.com/user-attachments/assets/947d2458-a311-427b-8357-8df935d2d076" />
<img width="769" height="462" alt="grafik" src="https://github.com/user-attachments/assets/df9f27a5-e0e9-4927-8e0f-ab79e791a0f1" />

In case there are any required changes feel free to let me know and I will look into that ASAP, thank you in advance for your review.