### PR TITLE
feat: schema colors

### DIFF
--- a/src/components/color-picker/color-picker.tsx
+++ b/src/components/color-picker/color-picker.tsx
@@ -13,52 +13,80 @@ export interface ColorPickerProps {
     disabled?: boolean;
     popoverOnMouseDown?: (e: React.MouseEvent) => void;
     popoverOnClick?: (e: React.MouseEvent) => void;
+    // When provided, renders a "clear" action in the popover (e.g. to reset a
+    // schema color back to the default).
+    onClear?: () => void;
+    clearLabel?: string;
 }
 
 export const ColorPicker = React.forwardRef<
     React.ElementRef<typeof PopoverTrigger>,
     ColorPickerProps
->(({ color, onChange, disabled, popoverOnMouseDown, popoverOnClick }, ref) => {
-    return (
-        <Popover>
-            <PopoverTrigger
-                asChild
-                ref={ref}
-                disabled={disabled}
-                {...(disabled ? { onClick: (e) => e.preventDefault() } : {})}
-            >
-                <div
-                    className={cn(
-                        'h-6 w-8 cursor-pointer rounded-md border-2 border-muted transition-shadow hover:shadow-md',
-                        {
-                            'hover:shadow-none cursor-default': disabled,
-                        }
-                    )}
-                    style={{
-                        backgroundColor: color,
-                    }}
-                />
-            </PopoverTrigger>
-            <PopoverContent
-                className="w-fit"
-                onMouseDown={popoverOnMouseDown}
-                onClick={popoverOnClick}
-            >
-                <div className="grid grid-cols-4 gap-2">
-                    {colorOptions.map((option) => (
-                        <div
-                            key={option}
-                            className="size-8 cursor-pointer rounded-md border-2 border-muted transition-shadow hover:shadow-md"
-                            style={{
-                                backgroundColor: option,
-                            }}
-                            onClick={() => onChange(option)}
-                        />
-                    ))}
-                </div>
-            </PopoverContent>
-        </Popover>
-    );
-});
+>(
+    (
+        {
+            color,
+            onChange,
+            disabled,
+            popoverOnMouseDown,
+            popoverOnClick,
+            onClear,
+            clearLabel = 'Clear',
+        },
+        ref
+    ) => {
+        return (
+            <Popover>
+                <PopoverTrigger
+                    asChild
+                    ref={ref}
+                    disabled={disabled}
+                    {...(disabled
+                        ? { onClick: (e) => e.preventDefault() }
+                        : {})}
+                >
+                    <div
+                        className={cn(
+                            'h-6 w-8 cursor-pointer rounded-md border-2 border-muted transition-shadow hover:shadow-md',
+                            {
+                                'hover:shadow-none cursor-default': disabled,
+                            }
+                        )}
+                        style={{
+                            backgroundColor: color,
+                        }}
+                    />
+                </PopoverTrigger>
+                <PopoverContent
+                    className="w-fit"
+                    onMouseDown={popoverOnMouseDown}
+                    onClick={popoverOnClick}
+                >
+                    <div className="grid grid-cols-4 gap-2">
+                        {colorOptions.map((option) => (
+                            <div
+                                key={option}
+                                className="size-8 cursor-pointer rounded-md border-2 border-muted transition-shadow hover:shadow-md"
+                                style={{
+                                    backgroundColor: option,
+                                }}
+                                onClick={() => onChange(option)}
+                            />
+                        ))}
+                    </div>
+                    {onClear ? (
+                        <button
+                            type="button"
+                            className="mt-2 w-full rounded-md border border-muted py-1 text-xs text-muted-foreground transition-colors hover:bg-muted"
+                            onClick={() => onClear()}
+                        >
+                            {clearLabel}
+                        </button>
+                    ) : null}
+                </PopoverContent>
+            </Popover>
+        );
+    }
+);
 
 ColorPicker.displayName = 'ColorPicker';

--- a/src/context/chartdb-context/chartdb-context.tsx
+++ b/src/context/chartdb-context/chartdb-context.tsx
@@ -8,7 +8,7 @@ import type { DBCheckConstraint } from '@/lib/domain/db-check-constraint';
 import type { DBRelationship } from '@/lib/domain/db-relationship';
 import type { Diagram } from '@/lib/domain/diagram';
 import type { DatabaseEdition } from '@/lib/domain/database-edition';
-import type { DBSchema } from '@/lib/domain/db-schema';
+import type { DBSchema, SchemaColors } from '@/lib/domain/db-schema';
 import type { DBDependency } from '@/lib/domain/db-dependency';
 import { EventEmitter } from 'ahooks/lib/useEventEmitter';
 import type { Area } from '@/lib/domain/area';
@@ -72,6 +72,11 @@ export interface ChartDBContext {
     databaseType: DatabaseType;
     tables: DBTable[];
     schemas: DBSchema[];
+    schemaColors: SchemaColors;
+    updateSchemaColor: (
+        schemaId: string,
+        color: string | null
+    ) => Promise<void>;
     relationships: DBRelationship[];
     dependencies: DBDependency[];
     areas: Area[];
@@ -341,6 +346,8 @@ export const chartDBContext = createContext<ChartDBContext>({
     customTypes: [],
     notes: [],
     schemas: [],
+    schemaColors: {},
+    updateSchemaColor: emptyFn,
     highlightCustomTypeId: emptyFn,
     currentDiagram: {
         id: '',

--- a/src/context/chartdb-context/chartdb-provider.tsx
+++ b/src/context/chartdb-context/chartdb-provider.tsx
@@ -16,7 +16,7 @@ import { useStorage } from '@/hooks/use-storage';
 import { useRedoUndoStack } from '@/hooks/use-redo-undo-stack';
 import type { Diagram } from '@/lib/domain/diagram';
 import type { DatabaseEdition } from '@/lib/domain/database-edition';
-import type { DBSchema } from '@/lib/domain/db-schema';
+import type { DBSchema, SchemaColors } from '@/lib/domain/db-schema';
 import {
     databasesWithSchemas,
     schemaNameToSchemaId,
@@ -71,6 +71,9 @@ export const ChartDBProvider: React.FC<
         diagram?.customTypes ?? []
     );
     const [notes, setNotes] = useState<Note[]>(diagram?.notes ?? []);
+    const [schemaColors, setSchemaColors] = useState<SchemaColors>(
+        diagram?.schemaColors ?? {}
+    );
 
     const { events: diffEvents } = useDiff();
 
@@ -154,6 +157,7 @@ export const ChartDBProvider: React.FC<
             areas,
             customTypes,
             notes,
+            schemaColors,
         }),
         [
             diagramId,
@@ -166,6 +170,7 @@ export const ChartDBProvider: React.FC<
             areas,
             customTypes,
             notes,
+            schemaColors,
             diagramCreatedAt,
             diagramUpdatedAt,
         ]
@@ -180,13 +185,17 @@ export const ChartDBProvider: React.FC<
             setAreas([]);
             setCustomTypes([]);
             setNotes([]);
+            setSchemaColors({});
             setDiagramUpdatedAt(updatedAt);
 
             resetRedoStack();
             resetUndoStack();
 
             await Promise.all([
-                db.updateDiagram({ id: diagramId, attributes: { updatedAt } }),
+                db.updateDiagram({
+                    id: diagramId,
+                    attributes: { updatedAt, schemaColors: {} },
+                }),
                 db.deleteDiagramTables(diagramId),
                 db.deleteDiagramRelationships(diagramId),
                 db.deleteDiagramDependencies(diagramId),
@@ -510,6 +519,30 @@ export const ChartDBProvider: React.FC<
             diagramId,
             events,
         ]
+    );
+
+    const updateSchemaColor: ChartDBContext['updateSchemaColor'] = useCallback(
+        async (schemaId: string, color: string | null) => {
+            let nextSchemaColors: SchemaColors = {};
+            setSchemaColors((prev) => {
+                const next = { ...prev };
+                if (color) {
+                    next[schemaId] = color;
+                } else {
+                    delete next[schemaId];
+                }
+                nextSchemaColors = next;
+                return next;
+            });
+
+            const updatedAt = new Date();
+            setDiagramUpdatedAt(updatedAt);
+            await db.updateDiagram({
+                id: diagramId,
+                attributes: { updatedAt, schemaColors: nextSchemaColors },
+            });
+        },
+        [db, diagramId, setSchemaColors, setDiagramUpdatedAt]
     );
 
     const updateTablesState: ChartDBContext['updateTablesState'] = useCallback(
@@ -1895,6 +1928,7 @@ export const ChartDBProvider: React.FC<
                 setDiagramUpdatedAt(diagram.updatedAt);
                 setHighlightedCustomTypeId(undefined);
                 setNotes(diagram.notes ?? []);
+                setSchemaColors(diagram.schemaColors ?? {});
 
                 events.emit({ action: 'load_diagram', data: { diagram } });
 
@@ -1916,6 +1950,7 @@ export const ChartDBProvider: React.FC<
                 setHighlightedCustomTypeId,
                 events,
                 setNotes,
+                setSchemaColors,
                 resetRedoStack,
                 resetUndoStack,
             ]
@@ -2108,6 +2143,8 @@ export const ChartDBProvider: React.FC<
                 notes,
                 currentDiagram,
                 schemas,
+                schemaColors,
+                updateSchemaColor,
                 events,
                 readonly,
                 updateDiagramData,

--- a/src/context/storage-context/storage-provider.tsx
+++ b/src/context/storage-context/storage-provider.tsx
@@ -631,6 +631,7 @@ export const StorageProvider: React.FC<React.PropsWithChildren> = ({
                     name: diagram.name,
                     databaseType: diagram.databaseType,
                     databaseEdition: diagram.databaseEdition,
+                    schemaColors: diagram.schemaColors,
                     createdAt: diagram.createdAt,
                     updatedAt: diagram.updatedAt,
                 })

--- a/src/lib/domain/__tests__/get-effective-table-color.test.ts
+++ b/src/lib/domain/__tests__/get-effective-table-color.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { getEffectiveTableColor } from '../db-schema';
+import type { DBTable } from '../db-table';
+
+const baseTable = (overrides: Partial<DBTable>): DBTable =>
+    ({
+        id: 't1',
+        name: 'users',
+        schema: 'public',
+        x: 0,
+        y: 0,
+        fields: [],
+        indexes: [],
+        color: '#111111',
+        isView: false,
+        createdAt: 0,
+        ...overrides,
+    }) as DBTable;
+
+describe('getEffectiveTableColor', () => {
+    it('inherits the schema color when the table color is not custom', () => {
+        const table = baseTable({ isColorCustom: false });
+        expect(getEffectiveTableColor(table, { public: '#22ff22' })).toBe(
+            '#22ff22'
+        );
+    });
+
+    it('keeps the table color when it was explicitly picked', () => {
+        const table = baseTable({ color: '#abcdef', isColorCustom: true });
+        expect(getEffectiveTableColor(table, { public: '#22ff22' })).toBe(
+            '#abcdef'
+        );
+    });
+
+    it('falls back to the table color when no schema color exists', () => {
+        const table = baseTable({ color: '#abcdef', isColorCustom: false });
+        expect(getEffectiveTableColor(table, {})).toBe('#abcdef');
+        expect(getEffectiveTableColor(table, undefined)).toBe('#abcdef');
+    });
+
+    it('matches schema colors via the normalized schema id', () => {
+        const table = baseTable({ schema: 'My Schema', isColorCustom: false });
+        expect(getEffectiveTableColor(table, { my_schema: '#123456' })).toBe(
+            '#123456'
+        );
+    });
+
+    it('ignores schema colors for tables without a schema', () => {
+        const table = baseTable({ schema: null, isColorCustom: false });
+        expect(getEffectiveTableColor(table, { public: '#22ff22' })).toBe(
+            '#111111'
+        );
+    });
+});

--- a/src/lib/domain/db-schema.ts
+++ b/src/lib/domain/db-schema.ts
@@ -1,5 +1,6 @@
 import { DATABASE_CAPABILITIES } from './database-capabilities';
 import type { DatabaseType } from './database-type';
+import type { DBTable } from './db-table';
 
 export interface DBSchema {
     id: string;
@@ -7,8 +8,31 @@ export interface DBSchema {
     tableCount: number;
 }
 
+// Per-diagram map of schema id -> hex color.
+export type SchemaColors = Record<string, string>;
+
 export const schemaNameToSchemaId = (schema: string): string =>
     schema.trim().toLowerCase().split(' ').join('_');
+
+// Resolve the color a table should render with, honoring the non-destructive
+// schema-color fallback: an explicitly user-picked color wins, otherwise the
+// table inherits its schema color, otherwise its own (default) color.
+export const getEffectiveTableColor = (
+    table: Pick<DBTable, 'color' | 'schema' | 'isColorCustom'>,
+    schemaColors?: SchemaColors
+): string => {
+    if (table.isColorCustom) {
+        return table.color;
+    }
+    const schemaName = schemaNameToDomainSchemaName(table.schema);
+    if (schemaName && schemaColors) {
+        const schemaColor = schemaColors[schemaNameToSchemaId(schemaName)];
+        if (schemaColor) {
+            return schemaColor;
+        }
+    }
+    return table.color;
+};
 
 export const schemaNameToDomainSchemaName = (
     schema: string | null | undefined

--- a/src/lib/domain/db-table.ts
+++ b/src/lib/domain/db-table.ts
@@ -25,6 +25,9 @@ export interface DBTable {
     indexes: DBIndex[];
     checkConstraints?: DBCheckConstraint[] | null;
     color: string;
+    // When true, `color` was explicitly picked by the user and overrides any
+    // schema-level color. When falsy, the table inherits its schema color (if any).
+    isColorCustom?: boolean | null;
     isView: boolean;
     isMaterializedView?: boolean | null;
     createdAt: number;
@@ -45,6 +48,7 @@ export const dbTableSchema: z.ZodType<DBTable> = z.object({
     indexes: z.array(dbIndexSchema),
     checkConstraints: z.array(dbCheckConstraintSchema).or(z.null()).optional(),
     color: z.string(),
+    isColorCustom: z.boolean().or(z.null()).optional(),
     isView: z.boolean(),
     isMaterializedView: z.boolean().or(z.null()).optional(),
     createdAt: z.number(),

--- a/src/lib/domain/diagram.ts
+++ b/src/lib/domain/diagram.ts
@@ -12,6 +12,7 @@ import type { DBCustomType } from './db-custom-type';
 import { dbCustomTypeSchema } from './db-custom-type';
 import type { Note } from './note';
 import { noteSchema } from './note';
+import type { SchemaColors } from './db-schema';
 
 export interface Diagram {
     id: string;
@@ -24,6 +25,9 @@ export interface Diagram {
     areas?: Area[];
     customTypes?: DBCustomType[];
     notes?: Note[];
+    // Per-schema default colors (schema id -> hex). Falls back onto tables that
+    // have not been given an explicit color. See getEffectiveTableColor.
+    schemaColors?: SchemaColors;
     createdAt: Date;
     updatedAt: Date;
 }
@@ -39,6 +43,7 @@ export const diagramSchema: z.ZodType<Diagram> = z.object({
     areas: z.array(areaSchema).optional(),
     customTypes: z.array(dbCustomTypeSchema).optional(),
     notes: z.array(noteSchema).optional(),
+    schemaColors: z.record(z.string(), z.string()).optional(),
     createdAt: z.date(),
     updatedAt: z.date(),
 });

--- a/src/pages/editor-page/canvas/canvas-filter/filter-item-actions.tsx
+++ b/src/pages/editor-page/canvas/canvas-filter/filter-item-actions.tsx
@@ -4,6 +4,9 @@ import { Button } from '@/components/button/button';
 import type { TreeNode } from '@/components/tree-view/tree';
 import { schemaNameToSchemaId } from '@/lib/domain/db-schema';
 import { useFocusOn } from '@/hooks/use-focus-on';
+import { useChartDB } from '@/hooks/use-chartdb';
+import { ColorPicker } from '@/components/color-picker/color-picker';
+import { defaultTableColor } from '@/lib/colors';
 import type {
     AreaContext,
     NodeContext,
@@ -43,38 +46,67 @@ export const FilterItemActions: React.FC<FilterItemActionsProps> = ({
     removeTablesFromFilter,
 }) => {
     const { focusOnArea, focusOnTable } = useFocusOn();
+    const { schemaColors, updateSchemaColor, readonly } = useChartDB();
     if (node.type === 'schema') {
         const context = node.context as SchemaContext;
         const schemaVisible = context.visible;
         const schemaName = context.name;
         const schemaId = schemaNameToSchemaId(schemaName);
+        const schemaColor = schemaColors[schemaId];
 
         return (
-            <Button
-                variant="ghost"
-                size="sm"
-                className="h-fit w-6 p-0"
-                onClick={(e) => {
-                    e.stopPropagation();
+            <div className="flex h-full items-center gap-0.5">
+                {databaseWithSchemas && !readonly ? (
+                    <div
+                        className={cn(
+                            'flex h-full items-center transition-opacity',
+                            schemaColor
+                                ? 'opacity-100'
+                                : 'opacity-0 group-hover:opacity-100'
+                        )}
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        <ColorPicker
+                            color={schemaColor ?? defaultTableColor}
+                            onChange={(color) =>
+                                updateSchemaColor(schemaId, color)
+                            }
+                            onClear={
+                                schemaColor
+                                    ? () => updateSchemaColor(schemaId, null)
+                                    : undefined
+                            }
+                            clearLabel="Reset schema color"
+                            popoverOnClick={(e) => e.stopPropagation()}
+                        />
+                    </div>
+                ) : null}
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-fit w-6 p-0"
+                    onClick={(e) => {
+                        e.stopPropagation();
 
-                    if (databaseWithSchemas) {
-                        toggleSchemaFilter(schemaId);
-                    } else {
-                        // Toggle visibility of all tables in this schema
-                        if (schemaVisible) {
-                            setTableIdsFilterEmpty();
+                        if (databaseWithSchemas) {
+                            toggleSchemaFilter(schemaId);
                         } else {
-                            clearTableIdsFilter();
+                            // Toggle visibility of all tables in this schema
+                            if (schemaVisible) {
+                                setTableIdsFilterEmpty();
+                            } else {
+                                clearTableIdsFilter();
+                            }
                         }
-                    }
-                }}
-            >
-                {!schemaVisible ? (
-                    <EyeOff className="!size-3.5 text-muted-foreground" />
-                ) : (
-                    <Eye className="!size-3.5" />
-                )}
-            </Button>
+                    }}
+                >
+                    {!schemaVisible ? (
+                        <EyeOff className="!size-3.5 text-muted-foreground" />
+                    ) : (
+                        <Eye className="!size-3.5" />
+                    )}
+                </Button>
+            </div>
         );
     }
 

--- a/src/pages/editor-page/canvas/table-node/table-edit-mode/table-edit-mode.tsx
+++ b/src/pages/editor-page/canvas/table-node/table-edit-mode/table-edit-mode.tsx
@@ -160,7 +160,10 @@ export const TableEditMode: React.FC<TableEditModeProps> = React.memo(
 
         const handleColorChange = useCallback(
             (newColor: string) => {
-                updateTable(table.id, { color: newColor });
+                updateTable(table.id, {
+                    color: newColor,
+                    isColorCustom: true,
+                });
             },
             [updateTable, table.id]
         );

--- a/src/pages/editor-page/canvas/table-node/table-node.tsx
+++ b/src/pages/editor-page/canvas/table-node/table-node.tsx
@@ -34,6 +34,7 @@ import {
     TABLE_MINIMIZED_FIELDS,
     type DBTable,
 } from '@/lib/domain/db-table';
+import { getEffectiveTableColor } from '@/lib/domain/db-schema';
 import { TableNodeField } from './table-node-field';
 import { useLayout } from '@/hooks/use-layout';
 import { useChartDB } from '@/hooks/use-chartdb';
@@ -86,7 +87,8 @@ export const TableNode: React.FC<NodeProps<TableNodeType>> = React.memo(
             targetEdgeCounts,
         },
     }) => {
-        const { updateTable, relationships, readonly } = useChartDB();
+        const { updateTable, relationships, readonly, schemaColors } =
+            useChartDB();
         const edges = useStore((store) => store.edges) as EdgeType[];
         const {
             openTableFromSidebar,
@@ -162,8 +164,8 @@ export const TableNode: React.FC<NodeProps<TableNodeType>> = React.memo(
                 return tableChangedColor.new;
             }
 
-            return table.color;
-        }, [tableChangedColor, table.color]);
+            return getEffectiveTableColor(table, schemaColors);
+        }, [tableChangedColor, table, schemaColors]);
 
         const [diffState, setDiffState] = useState<{
             isDiffTableChanged: boolean;

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-content/table-list-item-content.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-content/table-list-item-content.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/accordion/accordion';
 import { Separator } from '@/components/separator/separator';
 import type { DBTable } from '@/lib/domain/db-table';
+import { getEffectiveTableColor } from '@/lib/domain/db-schema';
 import type { DBField } from '@/lib/domain/db-field';
 import type { DBCheckConstraint } from '@/lib/domain/db-check-constraint';
 import { useChartDB } from '@/hooks/use-chartdb';
@@ -61,9 +62,10 @@ export const TableListItemContent: React.FC<TableListItemContentProps> = ({
         updateTable,
         readonly,
         databaseType,
+        schemaColors,
     } = useChartDB();
     const { t } = useTranslation();
-    const { color } = table;
+    const color = getEffectiveTableColor(table, schemaColors);
     const [selectedItems, setSelectedItems] = React.useState<
         AccordionItemValue[]
     >(['fields']);
@@ -416,7 +418,12 @@ export const TableListItemContent: React.FC<TableListItemContentProps> = ({
                 {!table.isView && !readonly ? (
                     <ColorPicker
                         color={color}
-                        onChange={(color) => updateTable(table.id, { color })}
+                        onChange={(color) =>
+                            updateTable(table.id, {
+                                color,
+                                isColorCustom: true,
+                            })
+                        }
                     />
                 ) : (
                     <div />


### PR DESCRIPTION
Assign a color to a schema; every table inherits it as its default.

Non-destructive fallback via `getEffectiveTableColor`: an explicitly picked table color (`isColorCustom`) wins, else the schema color, else the table's own default. Clearing restores prior appearance — no table data overwritten.

- `Diagram.schemaColors` + `DBTable.isColorCustom` (types, Zod, IndexedDB round-trip)
- `updateSchemaColor` store action
- ColorPicker + reset action on each filter-panel schema row
- Unit tests for the resolver

🤖 Generated with [Claude Code](https://claude.com/claude-code)