### PR TITLE
fix: escape JSON string values in MySQL/MariaDB smart queries

### DIFF
--- a/src/lib/data/import-metadata/scripts/maria-script.ts
+++ b/src/lib/data/import-metadata/scripts/maria-script.ts
@@ -1,7 +1,7 @@
 const withDefault = true;
 
-const withDefaultExpr = `IFNULL(REPLACE(REPLACE(cols.column_default, '\\\\', ''), '"', 'ֿֿֿ\\"'), '')`;
-const withoutDefault = `""`;
+const withDefaultExpr = `JSON_QUOTE(IFNULL(cols.column_default, ''))`;
+const withoutDefault = `'""'`;
 
 export const mariaDBQuery = `SET SESSION group_concat_max_len = 10000000;
 SELECT CAST(CONCAT(
@@ -60,8 +60,8 @@ SELECT CAST(CONCAT(
     IFNULL((SELECT GROUP_CONCAT(
         CONCAT('{"schema":"', cast(cols.table_schema as CHAR),
                '","table":"', cols.table_name,
-               '","name":"', REPLACE(cols.column_name, '"', '\\"'),
-               '","type":"', LOWER(cols.data_type),
+               '","name":', JSON_QUOTE(cols.column_name),
+               ',"type":"', LOWER(cols.data_type),
                '","character_maximum_length":"', IFNULL(cols.character_maximum_length, 'null'),
                '","precision":',
                IF(cols.data_type IN ('decimal', 'numeric'),
@@ -69,10 +69,10 @@ SELECT CAST(CONCAT(
                          ',"scale":', IFNULL(cols.numeric_scale, 'null'), '}'), 'null'),
                ',"ordinal_position":', cols.ordinal_position,
                ',"nullable":', IF(cols.is_nullable = 'YES', 'true', 'false'),
-               ',"default":"', ${withDefault ? withDefaultExpr : withoutDefault},
-               '","collation":"', IFNULL(cols.collation_name, ''),
+               ',"default":', ${withDefault ? withDefaultExpr : withoutDefault},
+               ',"collation":"', IFNULL(cols.collation_name, ''),
                '","is_identity":', IF(cols.extra LIKE '%auto_increment%', 'true', 'false'),
-               ',"comment":"', REPLACE(REPLACE(IFNULL(cols.column_comment, ''), '"', '\\"'), '\\n', ' '), '"}')
+               ',"comment":', JSON_QUOTE(IFNULL(cols.column_comment, '')), '}')
     ) FROM (
         SELECT cols.table_schema,
                cols.table_name,
@@ -130,7 +130,7 @@ SELECT CAST(CONCAT(
                ',"type":"', IFNULL(tbls.TABLE_TYPE, ''),
                '","engine":"', IFNULL(tbls.ENGINE, ''),
                '","collation":"', IFNULL(tbls.TABLE_COLLATION, ''),
-               '","comment":"', REPLACE(REPLACE(IFNULL(tbls.TABLE_COMMENT, ''), '"', '\\"'), '\\n', ' '), '"}')
+               '","comment":', JSON_QUOTE(IFNULL(tbls.TABLE_COMMENT, '')), '}')
     ) FROM (
         SELECT \`TABLE_SCHEMA\`,
                \`TABLE_NAME\`,
@@ -150,7 +150,7 @@ SELECT CAST(CONCAT(
     ) FROM (
         SELECT \`TABLE_SCHEMA\`,
                \`TABLE_NAME\` AS view_name,
-               null AS view_definition
+               '' AS view_definition
         FROM information_schema.views vws
         WHERE vws.table_schema = DATABASE()
     ) AS vws), ''),

--- a/src/lib/data/import-metadata/scripts/mysql-script.ts
+++ b/src/lib/data/import-metadata/scripts/mysql-script.ts
@@ -10,8 +10,8 @@ export const getMySQLQuery = (
 
     const withDefault = true;
 
-    const withDefaultExpr = `IFNULL(REPLACE(REPLACE(cols.column_default, '\\\\', ''), '"', 'ֿֿֿ\\"'), '')`;
-    const withoutDefault = `""`;
+    const withDefaultExpr = `JSON_QUOTE(IFNULL(cols.column_default, ''))`;
+    const withoutDefault = `'""'`;
 
     const newMySQLQuery = `WITH fk_info as (
 (SELECT (@fk_info:=NULL),
@@ -79,8 +79,8 @@ export const getMySQLQuery = (
            AND (0x00) IN (@cols := CONCAT_WS(',', @cols, CONCAT(
                 '{"schema":"', cols.table_schema,
                 '","table":"', cols.table_name,
-                '","name":"', REPLACE(cols.column_name, '"', '\\"'),
-                '","type":"', LOWER(cols.data_type),
+                '","name":', JSON_QUOTE(cols.column_name),
+                ',"type":"', LOWER(cols.data_type),
                 '","character_maximum_length":"', IFNULL(cols.character_maximum_length, 'null'),
                 '","precision":',
                     CASE
@@ -91,11 +91,11 @@ export const getMySQLQuery = (
                     END,
                 ',"ordinal_position":', cols.ordinal_position,
                 ',"nullable":', IF(cols.is_nullable = 'YES', 'true', 'false'),
-                ',"default":"', ${withDefault ? withDefaultExpr : withoutDefault},
-                '","collation":"', IFNULL(cols.collation_name, ''),
+                ',"default":', ${withDefault ? withDefaultExpr : withoutDefault},
+                ',"collation":"', IFNULL(cols.collation_name, ''),
                 '","is_identity":', IF(cols.extra LIKE '%auto_increment%', 'true', 'false'),
-                ',"comment":"', REPLACE(REPLACE(IFNULL(cols.column_comment, ''), '"', '\\\\"'), '\\n', ' '),
-                '"}'
+                ',"comment":', JSON_QUOTE(IFNULL(cols.column_comment, '')),
+                '}'
             )))))
 ), indexes as (
   (SELECT (@indexes:=NULL),
@@ -133,7 +133,7 @@ export const getMySQLQuery = (
                                              ', "type":"', IFNULL(\`TABLE_TYPE\`, ''), '",',
                                              '"engine":"', IFNULL(\`ENGINE\`, ''), '",',
                                              '"collation":"', IFNULL(\`TABLE_COLLATION\`, ''), '",',
-                                             '"comment":"', REPLACE(REPLACE(IFNULL(\`TABLE_COMMENT\`, ''), '"', '\\\\"'), '\\\\n', ' '), '"}')))))
+                                             '"comment":', JSON_QUOTE(IFNULL(\`TABLE_COMMENT\`, '')), '}')))))
 ), views as (
 (SELECT (@views:=NULL),
               (SELECT (0)
@@ -211,8 +211,8 @@ export const getMySQLQuery = (
     IFNULL((SELECT GROUP_CONCAT(
         CONCAT('{"schema":"', cast(cols.table_schema as CHAR),
                '","table":"', cols.table_name,
-               '","name":"', REPLACE(cols.column_name, '"', '\\"'),
-               '","type":"', LOWER(cols.data_type),
+               '","name":', JSON_QUOTE(cols.column_name),
+               ',"type":"', LOWER(cols.data_type),
                '","character_maximum_length":"', IFNULL(cols.character_maximum_length, 'null'),
                '","precision":',
                IF(cols.data_type IN ('decimal', 'numeric'),
@@ -220,9 +220,9 @@ export const getMySQLQuery = (
                          ',"scale":', IFNULL(cols.numeric_scale, 'null'), '}'), 'null'),
                ',"ordinal_position":', cols.ordinal_position,
                ',"nullable":', IF(cols.is_nullable = 'YES', 'true', 'false'),
-               ',"default":"', ${withDefault ? withDefaultExpr : withoutDefault},
-               '","collation":"', IFNULL(cols.collation_name, ''),
-               '","comment":"', REPLACE(REPLACE(IFNULL(cols.column_comment, ''), '"', '\\"'), '\\n', ' '), '"}')
+               ',"default":', ${withDefault ? withDefaultExpr : withoutDefault},
+               ',"collation":"', IFNULL(cols.collation_name, ''),
+               '","comment":', JSON_QUOTE(IFNULL(cols.column_comment, '')), '}')
     ) FROM (
         SELECT cols.table_schema,
                cols.table_name,
@@ -279,7 +279,7 @@ export const getMySQLQuery = (
                ',"type":"', IFNULL(tbls.TABLE_TYPE, ''),
                '","engine":"', IFNULL(tbls.ENGINE, ''),
                '","collation":"', IFNULL(tbls.TABLE_COLLATION, ''),
-               '","comment":"', REPLACE(REPLACE(IFNULL(tbls.TABLE_COMMENT, ''), '"', '\\\\"'), '\\\\n', ' '), '"}')
+               '","comment":', JSON_QUOTE(IFNULL(tbls.TABLE_COMMENT, '')), '}')
     ) FROM (
         SELECT \`TABLE_SCHEMA\`,
                \`TABLE_NAME\`,
@@ -299,7 +299,7 @@ export const getMySQLQuery = (
     ) FROM (
         SELECT \`TABLE_SCHEMA\`,
                \`TABLE_NAME\` AS view_name,
-               null AS view_definition
+               '' AS view_definition
         FROM information_schema.views vws
         WHERE vws.table_schema = DATABASE()
     ) AS vws), ''),


### PR DESCRIPTION
### Problem

The MySQL and MariaDB smart queries build their JSON by string concatenation, and two details of that concatenation are wrong. Both were reproduced against real servers (MariaDB 11.8 and MySQL 8.4 in Docker).

#### 1. Quote escaping is a no-op, so free-text values break the JSON

`maria-script.ts` and the MySQL 5.7 query escape double quotes with `REPLACE(value, '"', '\\"')`. Inside a TypeScript template literal `\\` collapses to a single backslash, so the server actually receives `REPLACE(value, '"', '\"')` — and MySQL parses `'\"'` as a plain `"`. The expression replaces a double quote with a double quote.

A single table is enough to break the import:

```sql
CREATE TABLE users (
  email VARCHAR(255) COMMENT 'the "primary" contact'
) COMMENT='holds "user" records';
```

```
"comment":"holds "user" records"      <- actual output
JSON.parse: Expected ',' or '}' after property value at position 1602
```

The user sees the generic "Invalid JSON. Please correct it or contact us at support@chartdb.io" error.

The same broken escape is used for `column_name` and `column_default` in **all three** query variants, so the MySQL 8 path is affected too — a column default such as `DEFAULT 'say "hi"'` breaks it. Before this change all three variants failed to parse on the reproduction schema.

Backslashes and newlines in comments have the same effect and were not handled at all (`column_default` had its backslashes silently stripped instead).

#### 2. Views are silently dropped

`maria-script.ts` and the MySQL 5.7 query select `null AS view_definition` and concatenate it into the row. In MySQL `CONCAT()` returns `NULL` if any argument is `NULL`, so every view row becomes `NULL`, and `GROUP_CONCAT` skips `NULL`s — the whole array comes back empty:

```
"views":[]        <- with 2 views present in the schema
```

There is no error: `views: []` satisfies `DatabaseMetadataSchema`, so the import succeeds and the diagram is simply missing every view. The MySQL 8 query emits a literal `"view_definition":""` and is unaffected.

### Fix

- Use the native `JSON_QUOTE()` for the free-text values (`column_name`, `column_default`, `column_comment`, `TABLE_COMMENT`) instead of hand-rolled `REPLACE` chains. It escapes quotes, backslashes, newlines and control characters correctly, and it removes the need for the `IFNULL(REPLACE(...))` workarounds. Available since MySQL 5.7.8 and MariaDB 10.2.3, both below the versions these queries already target.
- Select `'' AS view_definition` instead of `null`, so view rows survive `CONCAT`.

### Verification

Reproduction schema covering quotes, backslashes and newlines in table comments, column comments and column defaults, plus a column named `wei"rd`, two views, an FK and an index.

Before — all three query variants:

```
maria    | parse: FAIL
mysql8   | parse: FAIL
mysql57  | parse: FAIL
```

After:

```
maria    | parse: OK | views=2 tables=5 cols=12 idx=5 fk=1 pk=3
mysql8   | parse: OK | views=2 tables=5 cols=12 idx=5 fk=1 pk=3
mysql57  | parse: OK | views=2 tables=5 cols=12 idx=5 fk=1 pk=3
```

All three outputs pass `DatabaseMetadataSchema.safeParse`, and the values round-trip exactly:

```
table comment: "line1\nline2 with \"quotes\" and \\ backslash"
col comment  : "back\\slash and \"quote\""
column name  : "wei\"rd"
```

`npm run lint`, `tsc --noEmit`, `prettier --check` and `npm test` (833 tests) all pass.

### Note, not addressed here

Indexes whose `information_schema.statistics.COLUMN_NAME` is `NULL` — MySQL 8 functional indexes such as `CREATE INDEX i ON t((LOWER(name)))` — are dropped by the same `CONCAT`-with-`NULL` mechanism. Left out of this PR because a functional index has no column to map onto, so whether to emit it (and under what `column` value) is a product decision rather than a bug fix.
